### PR TITLE
#173: Can't edit name of Favorites on map

### DIFF
--- a/iBurn/ImageAnnotationView.swift
+++ b/iBurn/ImageAnnotationView.swift
@@ -71,6 +71,18 @@ final class ImageAnnotationView: MLNAnnotationView {
             break
         }
     }
+    
+    func addLongPressGesture(target: Any?, action: Selector, minimumPressDuration: TimeInterval = 0.5) {
+        guard gestureRecognizers?.first(where: { $0 is UILongPressGestureRecognizer }) == nil else {
+            return
+        }
+        
+        let longPressGesture = UILongPressGestureRecognizer(target: target, action: action)
+        longPressGesture.minimumPressDuration = minimumPressDuration
+        longPressGesture.cancelsTouchesInView = false
+        longPressGesture.delaysTouchesBegan = false
+        addGestureRecognizer(longPressGesture)
+    }
 }
 
 extension ImageAnnotationView {

--- a/iBurn/UserMapViewAdapter.swift
+++ b/iBurn/UserMapViewAdapter.swift
@@ -35,12 +35,6 @@ public class UserMapViewAdapter: MapViewAdapter {
         showEditMapPointTitleAlert(for: mapPoint)
     }
     
-    func createMapPoint(_ mapPoint: BRCMapPoint) {
-        clearEditingAnnotation()
-        mapView.addAnnotation(mapPoint)
-        mapView.selectAnnotation(mapPoint, animated: true, completionHandler: nil)
-    }
-    
     // MARK: - MLNMapViewDelegate Overrides
     
     override public func mapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {

--- a/iBurn/UserMapViewAdapter.swift
+++ b/iBurn/UserMapViewAdapter.swift
@@ -40,11 +40,16 @@ public class UserMapViewAdapter: MapViewAdapter {
         let annotationView = super.mapView(mapView, viewFor: annotation)
         guard let imageAnnotationView = annotationView as? ImageAnnotationView,
         let point = annotation as? BRCMapPoint else { return annotationView }
-        if point == editingAnnotation {
+        if point is BRCUserMapPoint {
             imageAnnotationView.isDraggable = true
-            imageAnnotationView.startDragging()
-        } else {
-            imageAnnotationView.isDraggable = false
+            imageAnnotationView.isUserInteractionEnabled = true
+            if imageAnnotationView.gestureRecognizers?.first(where: { $0 is UILongPressGestureRecognizer }) == nil {
+                let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleCalloutLongPress(_:)))
+                longPressGesture.minimumPressDuration = 0.5
+                longPressGesture.cancelsTouchesInView = false
+                longPressGesture.delaysTouchesBegan = false
+                imageAnnotationView.addGestureRecognizer(longPressGesture)
+            }
         }
         return imageAnnotationView
     }
@@ -165,6 +170,40 @@ private extension UserMapViewAdapter {
             self.mapView.removeAnnotation(mapPoint)
             DDLogInfo("Deleted user annotation: \(mapPoint)")
             self.reloadAnnotations()
+        }
+    }
+}
+
+// MARK: // Private
+
+private extension UserMapViewAdapter {
+    
+    @objc func handleCalloutLongPress(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began,
+              let annotationView = gesture.view as? ImageAnnotationView else { return }
+        
+        // If there's a selected annotation with callout showing, dismiss it to allow dragging
+        if let selectedAnnotation = mapView.selectedAnnotations.first {
+            DDLogInfo("Long press detected with callout showing - dismissing callout to enable dragging")
+            mapView.deselectAnnotation(selectedAnnotation, animated: false)
+            
+            // Find the annotation for this view and set it as editing
+            for (identifier, view) in annotationViews {
+                if view == annotationView {
+                    for annotation in mapView.annotations ?? [] {
+                        if ObjectIdentifier(annotation) == identifier,
+                           let mapPoint = annotation as? BRCMapPoint {
+                            self.editingAnnotation = mapPoint
+                            DDLogInfo("Set editing annotation after callout dismissal: \(mapPoint.title ?? "Untitled")")
+                            
+                            // Force the annotation to enter drag mode
+                            annotationView.setDragState(.starting, animated: true)
+                            break
+                        }
+                    }
+                    break
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for #173:

**1. Adds ability to edit favorite name**
Introduces an alert w/ text field. 

**2. Improves drag UX**
Introduces long press to move pin around. The draggability _seems_ improved as well, but I'm unable to test on a device (would like to test touch/drag with finger and haptic feedback).

![PR-edit-favorite](https://github.com/user-attachments/assets/699cf7fa-7461-4d34-ace5-0ec5e4503b23)
