### PR TITLE
Add map button to Event List screen

### DIFF
--- a/Docs/2025-08-04-event-list-map-button-fix.md
+++ b/Docs/2025-08-04-event-list-map-button-fix.md
@@ -1,0 +1,72 @@
+# Event List Map Button Fix
+
+## Date: 2025-08-04
+
+## High-Level Plan
+
+Fixed the issue where events weren't appearing on the map when using the Map button from the Event List screen.
+
+## Problem Analysis
+
+The initial implementation had a bug where no events were showing on the map despite:
+1. Events having location data (copied from camps/art during import)
+2. The map button being correctly implemented
+3. The annotation data source being properly connected
+
+### Root Cause
+The `YapViewAnnotationDataSource` was filtering events using `shouldShowOnMap()`, which only returns true for events that are:
+- Starting within 30 minutes OR happening right now
+- NOT ending soon
+- NOT already ended
+
+This filtering is appropriate for the main map but not for showing events from a list view.
+
+## Solution
+
+Added a `showAllEvents` flag to `YapViewAnnotationDataSource` that bypasses the temporal filtering for events.
+
+## Key Changes
+
+### AnnotationDataSource.swift
+1. **Added showAllEvents property** (lines 35, 37-39)
+   - `public var showAllEvents: Bool = false`
+   - Updated initializer to accept `showAllEvents` parameter
+
+2. **Modified filtering logic** (line 88)
+   - Changed from: `if event.shouldShowOnMap()`
+   - Changed to: `if showAllEvents || event.shouldShowOnMap()`
+
+### EventListViewController.swift
+1. **Updated mapButtonPressed** (line 205)
+   - Pass `showAllEvents: true` when creating data source
+   - Ensures all events from the list appear on the map
+
+## Technical Details
+
+### Design Decisions
+- Maintained backward compatibility by defaulting `showAllEvents` to false
+- Other screens using `YapViewAnnotationDataSource` continue to work as before
+- The fix is specific to list views that want to show all their items on a map
+
+### Alternative Approaches Considered
+- Creating a separate data source class - rejected as too much code duplication
+- Removing `shouldShowOnMap()` entirely - rejected as it's needed for the main map
+
+## Build Status
+
+✅ Project builds successfully with no errors
+
+## Expected Behavior
+
+1. Events screen shows map button in navigation bar (left side)
+2. Tapping map button shows ALL events from the current list on the map
+3. Events appear regardless of their start/end times
+4. The map zooms to show all event pins
+5. Other map views (main map, nearby) continue to filter events by time as before
+
+## Testing Notes
+
+- All events with valid locations should now appear on the map
+- Events without location data (no host camp/art) still won't appear
+- Day picker filter on Event List should affect which events show on the map
+- The fix doesn't affect how events appear on other map screens

--- a/Docs/2025-08-04-event-list-map-button.md
+++ b/Docs/2025-08-04-event-list-map-button.md
@@ -1,0 +1,54 @@
+# Event List Map Button Implementation
+
+## Date: 2025-08-04
+
+## High-Level Plan
+
+Added a map button to the EventListViewController that shows all visible events on a map view, following the existing pattern used in other list screens.
+
+## Solution Overview
+
+The implementation leverages the existing MapButtonHelper protocol and MapListViewController to provide consistent map functionality across all list views. The map button is placed in the leading navigation bar position (left side) as requested.
+
+## Key Changes
+
+### EventListViewController.swift
+
+1. **Added MapButtonHelper conformance** (lines 194-208)
+   - Custom `setupMapButton()` method creates a map icon button and places it in the left navigation bar position
+   - `mapButtonPressed()` method creates a YapViewAnnotationDataSource from the current event list data and pushes a MapListViewController
+
+2. **Updated viewDidLoad** (line 60)
+   - Added `setupMapButton()` call to initialize the map button during view setup
+
+## Technical Details
+
+### Implementation Pattern
+The solution follows the established pattern used in other list views:
+- `ObjectListViewController` already implements MapButtonHelper with right-side placement
+- `EventListViewController` now implements the same protocol with left-side placement
+- Both use `YapViewAnnotationDataSource` to convert list items to map annotations
+
+### Architecture Components Used
+- **MapButtonHelper protocol**: Provides interface for map button functionality
+- **YapViewAnnotationDataSource**: Converts YapDatabase view handler data to map annotations
+- **MapListViewController**: Displays list items on a map with automatic zoom to show all items
+- **UIBarButtonItem+Blocks**: Closure-based button handling for cleaner Swift code
+
+## Build Status
+
+✅ Project builds successfully with no errors or warnings
+
+## Expected Behavior
+
+1. Events screen now shows a map icon in the top-left navigation bar
+2. Tapping the map button pushes a map view showing all events from the current list
+3. The map automatically zooms to show all event pins
+4. Users can tap the list button on the map to return to the event list
+
+## Related Files
+
+- `/Users/chrisbal/Documents/Code/iBurn-iOS-2/iBurn/EventListViewController.swift` - Modified to add map functionality
+- `/Users/chrisbal/Documents/Code/iBurn-iOS-2/iBurn/MapButtonHelper.swift` - Protocol providing map button behavior
+- `/Users/chrisbal/Documents/Code/iBurn-iOS-2/iBurn/MapListViewController.swift` - Map view that displays list items
+- `/Users/chrisbal/Documents/Code/iBurn-iOS-2/iBurn/AnnotationDataSource.swift` - Data source implementations for map annotations

--- a/Docs/2025-08-04-event-map-list-button-fix.md
+++ b/Docs/2025-08-04-event-map-list-button-fix.md
@@ -1,0 +1,67 @@
+# Event Map List Button Fix
+
+## Date: 2025-08-04
+
+## High-Level Plan
+
+Fixed the issue where the list button on the event map view showed an empty list due to aggressive event filtering.
+
+## Problem Analysis
+
+When pressing the list button on the event map:
+1. ListButtonHelper correctly passed annotations to MapPinListViewController
+2. MapPinListViewController filtered annotations by visible bounds (working correctly)
+3. BRCDataSorter was called to sort the data objects
+4. **BRCDataSorter filtered out ALL events** based on timing restrictions
+
+### Root Cause
+The default `BRCDataSorterOptions` has:
+- `showExpiredEvents = false` - filters out past events
+- `showFutureEvents = false` - filters out future events
+
+This means only events happening "right now" would be shown, resulting in an empty list for most cases.
+
+## Solution
+
+Updated MapPinListViewController to show all events regardless of timing by setting both flags to true.
+
+## Key Changes
+
+### MapPinListViewController.swift (lines 61-62)
+```swift
+let options = BRCDataSorterOptions()
+options.showExpiredEvents = true  // Show all events regardless of timing
+options.showFutureEvents = true   // Show all events regardless of timing
+```
+
+## Technical Details
+
+### Why This Works
+- The map shows event pins regardless of timing (controlled by showAllEvents flag)
+- The list should show the same events that are visible on the map
+- Setting both flags to true ensures timing doesn't filter out events
+- Events are still sorted by distance if location is available
+
+### Other Components Unchanged
+- ListButtonHelper continues to work as designed
+- MapPinListViewController still filters by visible bounds
+- BRCDataSorter still sorts by distance when available
+
+## Build Status
+
+✅ Project builds successfully with no errors
+
+## Expected Behavior
+
+1. Open Event List screen
+2. Tap map button to see events on map
+3. Tap list button on the map view
+4. List shows all event pins visible in the current map bounds
+5. Events are sorted by distance from current location (if available)
+
+## Related Issues
+
+This fix complements the earlier changes:
+- Added map button to Event List screen
+- Fixed events not showing on map with showAllEvents flag
+- Now the list button properly shows those same events

--- a/iBurn/AnnotationDataSource.swift
+++ b/iBurn/AnnotationDataSource.swift
@@ -32,9 +32,11 @@ extension StaticAnnotationDataSource: AnnotationDataSource {
 
 public class YapViewAnnotationDataSource: NSObject {
     private let viewHandler: YapViewHandler
+    public var showAllEvents: Bool = false
     
-    init(viewHandler: YapViewHandler) {
+    init(viewHandler: YapViewHandler, showAllEvents: Bool = false) {
         self.viewHandler = viewHandler
+        self.showAllEvents = showAllEvents
     }
 }
 
@@ -83,7 +85,7 @@ extension YapViewAnnotationDataSource: AnnotationDataSource {
                 BRCEmbargo.canShowLocation(for: dataObject),
                     let annotation = annotation {
                     if let event = dataObject as? BRCEventObject {
-                        if event.shouldShowOnMap() {
+                        if showAllEvents || event.shouldShowOnMap() {
                             annotations.append(annotation)
                         }
                     } else {

--- a/iBurn/EventListViewController.swift
+++ b/iBurn/EventListViewController.swift
@@ -202,7 +202,7 @@ extension EventListViewController: MapButtonHelper {
     }
     
     func mapButtonPressed(_ sender: Any?) {
-        let dataSource = YapViewAnnotationDataSource(viewHandler: listCoordinator.tableViewAdapter.viewHandler)
+        let dataSource = YapViewAnnotationDataSource(viewHandler: listCoordinator.tableViewAdapter.viewHandler, showAllEvents: true)
         let mapVC = MapListViewController(dataSource: dataSource)
         navigationController?.pushViewController(mapVC, animated: true)
     }

--- a/iBurn/EventListViewController.swift
+++ b/iBurn/EventListViewController.swift
@@ -57,6 +57,7 @@ public class EventListViewController: UIViewController {
         setupFilterButton()
         setupListCoordinator()
         setupSearchButton()
+        setupMapButton()
         definesPresentationContext = true
         
         view.addSubview(tableView)
@@ -188,5 +189,21 @@ extension ASDayPicker: ColorTheme {
         dateTextColor = colors.primaryColor
         selectedWeekdayTextColor = colors.primaryColor
         outOfRangeDateTextColor = colors.detailColor
+    }
+}
+
+extension EventListViewController: MapButtonHelper {
+    func setupMapButton() {
+        let mapImage = UIImage(systemName: "map")
+        let map = UIBarButtonItem(image: mapImage, style: .plain) { [weak self] (button) in
+            self?.mapButtonPressed(button)
+        }
+        navigationItem.leftBarButtonItem = map
+    }
+    
+    func mapButtonPressed(_ sender: Any?) {
+        let dataSource = YapViewAnnotationDataSource(viewHandler: listCoordinator.tableViewAdapter.viewHandler)
+        let mapVC = MapListViewController(dataSource: dataSource)
+        navigationController?.pushViewController(mapVC, animated: true)
     }
 }

--- a/iBurn/MapPinListViewController.swift
+++ b/iBurn/MapPinListViewController.swift
@@ -58,6 +58,8 @@ public class MapPinListViewController: SortedViewController {
         
         // Sort using BRCDataSorter
         let options = BRCDataSorterOptions()
+        options.showExpiredEvents = true  // Show all events regardless of timing
+        options.showFutureEvents = true   // Show all events regardless of timing
         if let currentLocation = getCurrentLocation() {
             options.sortOrder = .distance(currentLocation)
         }


### PR DESCRIPTION
## Summary
- Added a map button to the Event List screen's navigation bar (left side)
- Allows users to view all visible events from the list on a map
- Follows the same pattern as other list screens (Camps, Favorites)

## Implementation Details
- Extended `EventListViewController` to conform to `MapButtonHelper` protocol
- Custom `setupMapButton()` places the button in the left navigation bar position
- Reuses existing `YapViewAnnotationDataSource` and `MapListViewController` infrastructure
- Map automatically zooms to show all event pins

## Test Plan
- [x] Build succeeds without errors
- [ ] Map button appears in Event List navigation bar
- [ ] Tapping map button shows all visible events on the map
- [ ] Can return to event list from map view
- [ ] Works correctly with day picker filter

🤖 Generated with [Claude Code](https://claude.ai/code)