### PR TITLE
Fix event type filtering mechanism

### DIFF
--- a/Docs/2025-08-04-fix-event-type-filtering.md
+++ b/Docs/2025-08-04-fix-event-type-filtering.md
@@ -1,0 +1,55 @@
+# Fix Event Type Filtering
+
+Date: 2025-08-04
+
+## Problem
+The event type filtering mechanism was broken. When users selected specific event types in the filter UI, all events were still being shown instead of just the selected types.
+
+## Root Cause
+There was a UserDefaults key mismatch between Swift and Objective-C code:
+- Swift UI (EventsFilterView.swift) was saving selected event types using key: `"selectedEventTypes"`
+- Objective-C database filter (NSUserDefaults+iBurn.m) was reading using key: `"kBRCSelectedEventsTypesKey"`
+
+Since these are different strings, the UI saved to one location but the database filter read from another, always getting an empty array. The database filter logic treats an empty array as "show all events", which is why all events were displayed regardless of selection.
+
+## Solution
+We consolidated the event filtering preferences into the existing UserSettings system:
+
+1. **Added keys to UserSettings.swift**:
+   - `selectedEventTypes = "kBRCSelectedEventsTypesKey"`
+   - `showExpiredEvents = "kBRCShowExpiredEventsKey"`
+   - `showAllDayEvents = "kBRCShowAllDayEventsKey"`
+
+2. **Added properties to UserSettings.swift**:
+   - `selectedEventTypes: [BRCEventType]` - handles conversion between Swift enum and NSNumber array
+   - `showExpiredEvents: Bool` - marked with @objc for Objective-C compatibility
+   - `showAllDayEvents: Bool` - marked with @objc for Objective-C compatibility
+
+3. **Updated EventsFilterView.swift**:
+   - Removed the custom UserDefaults extension
+   - Changed all references to use UserSettings properties instead
+   - This ensures both Swift and Objective-C use the same UserDefaults keys
+
+## Files Modified
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/UserSettings.swift` - Added event filtering properties
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/EventsFilterView.swift` - Updated to use UserSettings
+
+## Testing
+The project builds successfully. The filtering should now work correctly because both Swift and Objective-C code are reading/writing to the same UserDefaults keys.
+
+## Technical Details
+
+### Key Constants (from NSUserDefaults+iBurn.m)
+```objc
+static NSString *const kBRCSelectedEventsTypesKey = @"kBRCSelectedEventsTypesKey";
+static NSString *const kBRCShowExpiredEventsKey = @"kBRCShowExpiredEventsKey";
+static NSString *const kBRCShowAllDayEventsKey = @"kBRCShowAllDayEventsKey";
+```
+
+### Database Filter Logic (BRCDatabaseManager.m)
+The filter reads selected event types and creates an NSSet:
+```objc
+NSSet *filteredSet = [NSSet setWithArray:[[NSUserDefaults standardUserDefaults] selectedEventTypes]];
+```
+
+If the set is empty (`[eventTypes count] == 0`), all events pass the filter. This is the intended behavior - no selection means show all events.

--- a/iBurn/EventsFilterView.swift
+++ b/iBurn/EventsFilterView.swift
@@ -1,29 +1,6 @@
 import SwiftUI
 
-// MARK: - UserDefaults Extensions
-
-extension UserDefaults {
-    @objc var showExpiredEvents: Bool {
-        get { bool(forKey: "showExpiredEvents") }
-        set { set(newValue, forKey: "showExpiredEvents") }
-    }
-    
-    @objc var showAllDayEvents: Bool {
-        get { bool(forKey: "showAllDayEvents") }
-        set { set(newValue, forKey: "showAllDayEvents") }
-    }
-    
-    var selectedEventTypes: [BRCEventType] {
-        get { 
-            guard let numbers = array(forKey: "selectedEventTypes") as? [NSNumber] else { return [] }
-            return numbers.compactMap { BRCEventType(rawValue: $0.uintValue) }
-        }
-        set { 
-            let numbers = newValue.map { NSNumber(value: $0.rawValue) }
-            set(numbers, forKey: "selectedEventTypes")
-        }
-    }
-}
+// MARK: - Models
 
 // MARK: - Models
 
@@ -47,13 +24,13 @@ class EventsFilterViewModel: ObservableObject {
     
     init(onFilterChanged: (() -> Void)? = nil) {
         self.onFilterChanged = onFilterChanged
-        // Initialize from UserDefaults
-        self.showExpiredEvents = UserDefaults.standard.showExpiredEvents
+        // Initialize from UserSettings
+        self.showExpiredEvents = UserSettings.showExpiredEvents
         self.searchSelectedDayOnly = UserSettings.searchSelectedDayOnly
-        self.showAllDayEvents = UserDefaults.standard.showAllDayEvents
+        self.showAllDayEvents = UserSettings.showAllDayEvents
         
         // Initialize event types
-        let storedTypes = UserDefaults.standard.selectedEventTypes
+        let storedTypes = UserSettings.selectedEventTypes
         self.eventTypes = BRCEventObject.allVisibleEventTypes.compactMap { number -> EventTypeContainer? in
             guard let type = BRCEventType(rawValue: number.uintValue) else { return nil }
             return EventTypeContainer(
@@ -73,16 +50,16 @@ class EventsFilterViewModel: ObservableObject {
     }
     
     func saveSettings() {
-        // Save to UserDefaults
-        UserDefaults.standard.showExpiredEvents = showExpiredEvents
+        // Save to UserSettings
+        UserSettings.showExpiredEvents = showExpiredEvents
         UserSettings.searchSelectedDayOnly = searchSelectedDayOnly
-        UserDefaults.standard.showAllDayEvents = showAllDayEvents
+        UserSettings.showAllDayEvents = showAllDayEvents
         
         // Save selected event types
         let selectedTypes = eventTypes
             .filter { $0.isSelected }
             .map { $0.type }
-        UserDefaults.standard.selectedEventTypes = selectedTypes
+        UserSettings.selectedEventTypes = selectedTypes
         
         // Notify of changes
         onFilterChanged?()

--- a/iBurn/UserSettings.swift
+++ b/iBurn/UserSettings.swift
@@ -19,6 +19,9 @@ public final class UserSettings: NSObject {
         static let favoritesFilter = "FavoritesFilter"
         static let nearbyFilter = "NearbyFilter"
         static let useImageColorsTheming = "UseImageColorsTheming"
+        static let selectedEventTypes = "kBRCSelectedEventsTypesKey"
+        static let showExpiredEvents = "kBRCShowExpiredEventsKey"
+        static let showAllDayEvents = "kBRCShowAllDayEventsKey"
     }
     
     /// Selected favorites filter
@@ -92,6 +95,38 @@ public final class UserSettings: NSObject {
                 return true
             }
             return UserDefaults.standard.bool(forKey: Keys.useImageColorsTheming)
+        }
+    }
+    
+    /// Selected event types for filtering
+    public static var selectedEventTypes: [BRCEventType] {
+        set {
+            let numbers = newValue.map { NSNumber(value: $0.rawValue) }
+            UserDefaults.standard.set(numbers, forKey: Keys.selectedEventTypes)
+        }
+        get {
+            guard let numbers = UserDefaults.standard.array(forKey: Keys.selectedEventTypes) as? [NSNumber] else { return [] }
+            return numbers.compactMap { BRCEventType(rawValue: $0.uintValue) }
+        }
+    }
+    
+    /// Show expired events
+    @objc public static var showExpiredEvents: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Keys.showExpiredEvents)
+        }
+        get {
+            return UserDefaults.standard.bool(forKey: Keys.showExpiredEvents)
+        }
+    }
+    
+    /// Show all day events
+    @objc public static var showAllDayEvents: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Keys.showAllDayEvents)
+        }
+        get {
+            return UserDefaults.standard.bool(forKey: Keys.showAllDayEvents)
         }
     }
     


### PR DESCRIPTION
## Summary
- Fixed broken event type filtering that was showing all events regardless of selected types
- Consolidated event preferences into UserSettings for consistency
- Resolved UserDefaults key mismatch between Swift and Objective-C code

## Problem
The event type filtering wasn't working - selecting specific event types in the filter UI still showed all events instead of just the selected types.

## Root Cause
There was a UserDefaults key mismatch:
- Swift UI saved to: `"selectedEventTypes"`
- Objective-C read from: `"kBRCSelectedEventsTypesKey"`

This caused the database filter to always get an empty array, which is treated as "show all events".

## Solution
1. Added event filtering properties to `UserSettings.swift` using the correct Objective-C keys
2. Updated `EventsFilterView.swift` to use UserSettings instead of custom UserDefaults extension
3. This ensures both Swift and Objective-C use the same keys

## Test Plan
- [x] Build succeeds
- [ ] Open Events tab and tap filter button
- [ ] Select specific event types (e.g., only "Workshop" and "Performance")
- [ ] Verify only selected event types appear in the list
- [ ] Toggle "Show Expired Events" and verify it works
- [ ] Toggle "Show All Day Events" and verify it works

🤖 Generated with [Claude Code](https://claude.ai/code)