### PR TITLE
Remove confusing embargo screen from onboarding flow

### DIFF
--- a/Docs/2025-08-06-embargo-view-ui-improvements.md
+++ b/Docs/2025-08-06-embargo-view-ui-improvements.md
@@ -1,0 +1,71 @@
+# Embargo View UI Improvements
+
+## Date: 2025-08-06
+
+## Overview
+Enhanced the EmbargoPasscodeView UI with two key improvements:
+1. Added a system-style close (X) button overlay in the top right corner
+2. Added a toggle to show/hide the passcode entry field with playful text
+
+## Changes Made
+
+### 1. Close Button Overlay
+**File Modified:** `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/EmbargoPasscodeView.swift`
+
+Added a close button overlay to the ScrollView using SwiftUI's `.overlay` modifier:
+- Positioned in top-right corner with `.topTrailing` alignment
+- Uses SF Symbol "xmark.circle.fill" for standard iOS appearance
+- Styled with white X on semi-transparent black background
+- Calls the existing `dismissAction` when tapped
+- Provides better UX alongside the existing Skip button
+
+### 2. Toggle for Passcode Entry
+**Files Modified:**
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/EmbargoPasscodeViewModel.swift`
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/EmbargoPasscodeView.swift`
+
+Added a toggle control to show/hide the passcode entry:
+- New `@Published` property `showPasscodeEntry` in view model
+- Toggle with text "I am super special and am allowed early access"
+- Conditionally displays the passcode SecureField and Unlock button
+- Maintains consistent styling with the rest of the view
+
+## Technical Implementation
+
+### Close Button Code
+```swift
+.overlay(alignment: .topTrailing) {
+    Button(action: {
+        viewModel.dismissAction?()
+    }) {
+        Image(systemName: "xmark.circle.fill")
+            .font(.largeTitle)
+            .symbolRenderingMode(.palette)
+            .foregroundStyle(.white, .black.opacity(0.6))
+            .clipShape(Circle())
+    }
+    .padding()
+}
+```
+
+### Toggle Implementation
+```swift
+Toggle("I am super special and am allowed early access", isOn: $viewModel.showPasscodeEntry)
+    .toggleStyle(SwitchToggleStyle(tint: Color(colors.primaryColor)))
+    .foregroundColor(.black)
+    .padding(.horizontal)
+
+if viewModel.showPasscodeEntry {
+    // Existing HStack with passcode field and unlock button
+}
+```
+
+## Context
+The embargo view is presented as a full-screen modal from the More tab when users tap on "Unlock Location Data". This view explains the data embargo imposed by Burning Man organization and allows users with special access to enter a passcode to unlock location data early.
+
+## Build Status
+✅ Build successful - No compilation errors
+
+## Related Work
+- Previous commit removed the embargo screen from the onboarding flow
+- Embargo screen now only accessible through More tab for manual unlock

--- a/Docs/2025-08-06-remove-embargo-screen-from-onboarding.md
+++ b/Docs/2025-08-06-remove-embargo-screen-from-onboarding.md
@@ -1,0 +1,91 @@
+# Remove Embargo Screen from Onboarding Flow
+
+## Date: 2025-08-06
+
+## Problem Statement
+The location unlock/embargo screen appearing immediately after onboarding was confusing for users. It presented a passcode entry screen that created friction and uncertainty about data availability.
+
+## Solution Overview
+Replaced the full embargo screen presentation with a simple informational alert that explains when location data will be available, maintaining transparency while reducing user confusion.
+
+## Key Changes
+
+### 1. Modified Onboarding Completion Flow
+**File**: `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/BRCAppDelegate.m`
+**Method**: `setupNormalRootViewController` (lines 414-437)
+
+#### Previous Implementation:
+- After onboarding, immediately presented `EmbargoPasscodeView` if data was embargoed
+- Required user interaction with passcode field or skip button
+- Modal full-screen presentation blocked access to app
+
+#### New Implementation:
+- Shows simple `UIAlertController` with informational message
+- Single "OK" button for easy dismissal
+- Non-blocking - users can immediately access the app
+
+### Alert Content
+```objc
+Title: "Location Data Coming Soon"
+Message: "Camp location data is restricted until one week before gates open, 
+         and art location data is restricted until the event starts. 
+         This is due to an embargo imposed by the Burning Man organization.
+         
+         The app will automatically unlock itself after gates open at 
+         12:01am Sunday and you're on playa."
+Button: "OK"
+```
+
+## Technical Details
+
+### Code Change
+Replaced embargo screen presentation logic with alert:
+
+```objc
+// Show informational alert about embargo if needed
+if (![BRCEmbargo allowEmbargoedData]) {
+    UIAlertController *alert = [UIAlertController 
+        alertControllerWithTitle:@"Location Data Coming Soon" 
+        message:@"Camp location data is restricted..." 
+        preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *okAction = [UIAlertAction 
+        actionWithTitle:@"OK" 
+        style:UIAlertActionStyleDefault 
+        handler:nil];
+    
+    [alert addAction:okAction];
+    [self.tabBarController presentViewController:alert animated:YES completion:nil];
+}
+```
+
+## Expected Outcomes
+
+### User Experience Improvements:
+1. **Reduced Friction**: Users no longer face a complex passcode screen after onboarding
+2. **Clear Communication**: Alert explains data restrictions without requiring action
+3. **Immediate Access**: Users can dismiss alert and explore the app immediately
+4. **Preserved Functionality**: Manual unlock still available in More tab for those with passcode
+
+### Unchanged Functionality:
+- Automatic unlock still occurs when gates open
+- Region-based unlock continues to work
+- Manual passcode entry remains available in More tab
+- Data embargo logic unchanged
+
+## Testing Performed
+- Built project successfully with `xcodebuild`
+- No compilation errors
+- Alert presentation logic verified
+
+## Related Files
+- `EmbargoPasscodeView.swift` - Still used for manual unlock in More tab
+- `EmbargoPasscodeViewModel.swift` - Embargo logic unchanged
+- `BRCEmbargo.m` - Core embargo functionality preserved
+- `MoreViewController.swift` - Manual unlock option remains
+
+## Notes
+- This change only affects the post-onboarding flow
+- Users who have already completed onboarding won't see any change
+- The embargo system itself remains fully functional
+- Consider monitoring user feedback to ensure the alert provides sufficient information

--- a/iBurn/BRCAppDelegate.m
+++ b/iBurn/BRCAppDelegate.m
@@ -422,13 +422,13 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     // Show informational alert about embargo if needed
     if (![BRCEmbargo allowEmbargoedData]) {
         UIAlertController *alert = [UIAlertController 
-            alertControllerWithTitle:@"Location Data Coming Soon" 
+            alertControllerWithTitle:@"Locations Are Hidden"
             message:@"Camp location data is restricted until one week before gates open, and art location data is restricted until the event starts. This is due to an embargo imposed by the Burning Man organization.\n\nDon't worry, the app will automatically unlock itself after gates open at 12:01am Sunday and you're on playa."
             preferredStyle:UIAlertControllerStyleAlert];
         
         UIAlertAction *okAction = [UIAlertAction 
-            actionWithTitle:@"OK" 
-            style:UIAlertActionStyleDefault 
+            actionWithTitle:@"Ok cool whatever"
+            style:UIAlertActionStyleDefault
             handler:nil];
         
         [alert addAction:okAction];

--- a/iBurn/BRCAppDelegate.m
+++ b/iBurn/BRCAppDelegate.m
@@ -423,7 +423,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     if (![BRCEmbargo allowEmbargoedData]) {
         UIAlertController *alert = [UIAlertController 
             alertControllerWithTitle:@"Location Data Coming Soon" 
-            message:@"Camp location data is restricted until one week before gates open, and art location data is restricted until the event starts. This is due to an embargo imposed by the Burning Man organization.\n\nThe app will automatically unlock itself after gates open at 12:01am Sunday and you're on playa." 
+            message:@"Camp location data is restricted until one week before gates open, and art location data is restricted until the event starts. This is due to an embargo imposed by the Burning Man organization.\n\nDon't worry, the app will automatically unlock itself after gates open at 12:01am Sunday and you're on playa."
             preferredStyle:UIAlertControllerStyleAlert];
         
         UIAlertAction *okAction = [UIAlertAction 

--- a/iBurn/BRCAppDelegate.m
+++ b/iBurn/BRCAppDelegate.m
@@ -419,13 +419,20 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     [[self class] registerForRemoteNotifications];
     [self requestLocationPermission];
 
-    // Present Embargo Screen if needed
+    // Show informational alert about embargo if needed
     if (![BRCEmbargo allowEmbargoedData]) {
-        UIViewController *hostingController = [EmbargoPasscodeFactory makeViewControllerWithDismissAction:^{
-            [self.tabBarController dismissViewControllerAnimated:YES completion:nil];
-        }];
-        hostingController.modalPresentationStyle = UIModalPresentationFullScreen;
-        [self.tabBarController presentViewController:hostingController animated:YES completion:nil];
+        UIAlertController *alert = [UIAlertController 
+            alertControllerWithTitle:@"Location Data Coming Soon" 
+            message:@"Camp location data is restricted until one week before gates open, and art location data is restricted until the event starts. This is due to an embargo imposed by the Burning Man organization.\n\nThe app will automatically unlock itself after gates open at 12:01am Sunday and you're on playa." 
+            preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction *okAction = [UIAlertAction 
+            actionWithTitle:@"OK" 
+            style:UIAlertActionStyleDefault 
+            handler:nil];
+        
+        [alert addAction:okAction];
+        [self.tabBarController presentViewController:alert animated:YES completion:nil];
     }
 }
 

--- a/iBurn/EmbargoPasscodeView.swift
+++ b/iBurn/EmbargoPasscodeView.swift
@@ -23,17 +23,20 @@ struct EmbargoPasscodeView: View {
                         .foregroundColor(.black)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
+                    
+                    Spacer()
 
-                    Toggle("I am super special and am allowed early access", isOn: $viewModel.showPasscodeEntry)
+                    Toggle("I am super special and have authorization to access this data early",
+                           isOn: $viewModel.showPasscodeEntry)
                         .toggleStyle(SwitchToggleStyle(tint: Color(colors.primaryColor)))
                         .foregroundColor(.black)
                         .padding(.horizontal)
+                        .font(.footnote)
                     
                     if viewModel.showPasscodeEntry {
-                        HStack {
+                        HStack(spacing: 5) {
                             SecureField("Passcode", text: $viewModel.passcode)
                                 .textFieldStyle(.roundedBorder)
-                                .padding(10)
                                 .textContentType(.password)
                                 .foregroundColor(.black)
                                 .modifier(ShakeEffect(shakes: viewModel.shouldShowUnlockError ? 3 : 0))

--- a/iBurn/EmbargoPasscodeView.swift
+++ b/iBurn/EmbargoPasscodeView.swift
@@ -9,6 +9,8 @@ struct EmbargoPasscodeView: View {
         
         ScrollView {
             VStack(spacing: 20) {
+                Spacer()
+                    .frame(height: 20)
                 Text(viewModel.countdownString)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.black)
@@ -16,36 +18,29 @@ struct EmbargoPasscodeView: View {
                     .padding(.top)
 
                 if !viewModel.isDataUnlocked {
-                    Text("Camp location data is restricted until one week before gates open, and art location data is restricted until the event starts. This is due to an embargo imposed by the Burning Man organization. \n\nThe app will automatically unlock itself after gates open at 12:01am Sunday and you're on playa. \n\nWe will post the passcode publicly after gates open. Please do not ask us for the passcode, thanks!")
+                    Text("Camp location data is restricted until one week before gates open, and art location data is restricted until the event starts. This is due to an embargo imposed by the Burning Man organization. \n\nDon't worry, the app will automatically unlock itself after gates open at 12:01am Sunday and you're on playa.")
                         .font(.body)
                         .foregroundColor(.black)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
 
-                    socialButtonsView(colors: colors)
-                        .padding(.top, 10)
-
-                    SecureField("Passcode", text: $viewModel.passcode)
-                        .textFieldStyle(.roundedBorder)
-                        .padding(10)
-                        .textContentType(.password)
-                        .foregroundColor(.black)
-                        .modifier(ShakeEffect(shakes: viewModel.shouldShowUnlockError ? 3 : 0))
-                        .animation(viewModel.shouldShowUnlockError ? .default : nil, value: viewModel.shouldShowUnlockError)
-                        .onChange(of: viewModel.shouldShowUnlockError) { newValue in
-                            if newValue {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                    viewModel.shouldShowUnlockError = false
-                                }
-                            }
-                        }
+                    
                     
                     HStack {
-                        Button("Skip") {
-                            viewModel.skipButtonPressed()
-                        }
-                        .buttonStyle(.bordered)
-                        .accentColor(Color(colors.secondaryColor))
+                        SecureField("Passcode", text: $viewModel.passcode)
+                            .textFieldStyle(.roundedBorder)
+                            .padding(10)
+                            .textContentType(.password)
+                            .foregroundColor(.black)
+                            .modifier(ShakeEffect(shakes: viewModel.shouldShowUnlockError ? 3 : 0))
+                            .animation(viewModel.shouldShowUnlockError ? .default : nil, value: viewModel.shouldShowUnlockError)
+                            .onChange(of: viewModel.shouldShowUnlockError) { newValue in
+                                if newValue {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                        viewModel.shouldShowUnlockError = false
+                                    }
+                                }
+                            }
 
                         Spacer()
 
@@ -61,6 +56,19 @@ struct EmbargoPasscodeView: View {
             }
             .padding(.vertical)
             .padding(.horizontal)
+        }
+        .overlay(alignment: .topTrailing) {
+            Button(action: {
+                viewModel.dismissAction?()
+            }) {
+                // Close Button
+                Image(systemName: "xmark.circle.fill")
+                    .font(.largeTitle)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .black.opacity(0.6))
+                    .clipShape(Circle())
+            }
+            .padding()
         }
         .background(
             Image("PlayaBackground")
@@ -83,57 +91,6 @@ struct EmbargoPasscodeView: View {
                 }
             }
         }
-        .sheet(isPresented: $viewModel.showingSocialWebView) {
-            if let url = viewModel.socialURLToOpen {
-                SafariView(url: url)
-                    .onDisappear {
-                        self.viewModel.socialURLToOpen = nil
-                    }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func socialButtonsView(colors: BRCImageColors) -> some View {
-        // UPDATED: Social links and button style
-        let socialLinks: [(name: String, urlString: String)] = [
-            (name: "Facebook", urlString: "https://facebook.com/iBurnApp"),
-            (name: "GitHub", urlString: "https://github.com/iBurnApp/iBurn-iOS")
-        ]
-
-        HStack(spacing: 20) { // Adjusted spacing for text buttons
-            ForEach(socialLinks, id: \.urlString) { link in
-                if let url = URL(string: link.urlString) {
-                    Button(action: {
-                        // Fallback to web URL for all links now
-                        self.viewModel.socialURLToOpen = url
-                        self.viewModel.showingSocialWebView = true
-                    }) {
-                        Text(link.name)
-                    }
-                    .buttonStyle(.bordered)
-                    .accentColor(Color(colors.secondaryColor))
-                    .accessibilityLabel(link.name)
-                }
-            }
-        }
-    }
-}
-
-// Helper for SFSafariViewController - remains the same
-struct SafariView: UIViewControllerRepresentable {
-    let url: URL
-
-    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
-        let config = SFSafariViewController.Configuration()
-        // config.entersReaderIfAvailable = true // Optional: enable reader mode
-        let vc = SFSafariViewController(url: url, configuration: config)
-        vc.preferredControlTintColor = Appearance.currentColors.primaryColor // Match app's tint color
-        return vc
-    }
-
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
-        // No update needed
     }
 }
 

--- a/iBurn/EmbargoPasscodeView.swift
+++ b/iBurn/EmbargoPasscodeView.swift
@@ -24,34 +24,39 @@ struct EmbargoPasscodeView: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
 
+                    Toggle("I am super special and am allowed early access", isOn: $viewModel.showPasscodeEntry)
+                        .toggleStyle(SwitchToggleStyle(tint: Color(colors.primaryColor)))
+                        .foregroundColor(.black)
+                        .padding(.horizontal)
                     
-                    
-                    HStack {
-                        SecureField("Passcode", text: $viewModel.passcode)
-                            .textFieldStyle(.roundedBorder)
-                            .padding(10)
-                            .textContentType(.password)
-                            .foregroundColor(.black)
-                            .modifier(ShakeEffect(shakes: viewModel.shouldShowUnlockError ? 3 : 0))
-                            .animation(viewModel.shouldShowUnlockError ? .default : nil, value: viewModel.shouldShowUnlockError)
-                            .onChange(of: viewModel.shouldShowUnlockError) { newValue in
-                                if newValue {
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                        viewModel.shouldShowUnlockError = false
+                    if viewModel.showPasscodeEntry {
+                        HStack {
+                            SecureField("Passcode", text: $viewModel.passcode)
+                                .textFieldStyle(.roundedBorder)
+                                .padding(10)
+                                .textContentType(.password)
+                                .foregroundColor(.black)
+                                .modifier(ShakeEffect(shakes: viewModel.shouldShowUnlockError ? 3 : 0))
+                                .animation(viewModel.shouldShowUnlockError ? .default : nil, value: viewModel.shouldShowUnlockError)
+                                .onChange(of: viewModel.shouldShowUnlockError) { newValue in
+                                    if newValue {
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                            viewModel.shouldShowUnlockError = false
+                                        }
                                     }
                                 }
+
+                            Spacer()
+
+                            Button("Unlock") {
+                                viewModel.unlockButtonPressed()
                             }
-
-                        Spacer()
-
-                        Button("Unlock") {
-                            viewModel.unlockButtonPressed()
+                            .font(.body.bold())
+                            .buttonStyle(.borderedProminent)
+                            .accentColor(Color(colors.primaryColor))
                         }
-                        .font(.body.bold())
-                        .buttonStyle(.borderedProminent)
-                        .accentColor(Color(colors.primaryColor))
+                        .padding(.horizontal)
                     }
-                    .padding(.horizontal)
                 }
             }
             .padding(.vertical)

--- a/iBurn/EmbargoPasscodeViewModel.swift
+++ b/iBurn/EmbargoPasscodeViewModel.swift
@@ -8,6 +8,7 @@ class EmbargoPasscodeViewModel: ObservableObject {
     @Published var shouldShowUnlockError: Bool = false
     @Published var showingSocialWebView: Bool = false
     @Published var socialURLToOpen: URL? = nil
+    @Published var showPasscodeEntry: Bool = false
     
     private var countdownTimer: Timer?
     private let festivalStartDate: Date = BRCEventObject.festivalStartDate()

--- a/iBurn/MoreViewController.swift
+++ b/iBurn/MoreViewController.swift
@@ -338,7 +338,6 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
         let unlockVC = EmbargoPasscodeHostingViewController { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }
-        unlockVC.modalPresentationStyle = .fullScreen
         present(unlockVC, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
## Summary
- Replaced full embargo/passcode screen after onboarding with a simple informational alert
- Alert explains when location data will be available with just an OK button
- Reduces user friction while maintaining transparency about data restrictions

## Changes
- Modified `setupNormalRootViewController` in `BRCAppDelegate.m` to show `UIAlertController` instead of `EmbargoPasscodeView`
- Alert shows only if embargo is active (same condition as before)
- Manual unlock still available in More tab for users with passcode

## Alert Content
**Title:** "Location Data Coming Soon"

**Message:** Explains camp/art location data restrictions and automatic unlock when gates open

**Action:** Single "OK" button to dismiss

## Testing
- ✅ Built successfully with xcodebuild
- ✅ No compilation errors
- ✅ Alert logic verified in code

## Why This Change?
The embargo screen appearing immediately after onboarding was confusing for new users. They were presented with a passcode field without context, creating uncertainty about whether they needed special access. This simpler approach:
- Provides the same information in a less intimidating format
- Doesn't block app exploration
- Maintains all existing embargo functionality

🤖 Generated with [Claude Code](https://claude.ai/code)