### PR TITLE
Replace text 'Filter' and 'Map' with icons in navigation bar

### DIFF
--- a/Docs/2025-08-10-filter-map-icon-consistency.md
+++ b/Docs/2025-08-10-filter-map-icon-consistency.md
@@ -1,0 +1,90 @@
+# Filter and Map Icon Consistency Update
+
+## Date: 2025-08-10
+
+## High-Level Plan
+
+Replace text labels "Filter" and "Map" with icons in navigation bar buttons to ensure consistency across all view controllers in the app.
+
+## Problem Statement
+
+Some view controllers were still using text labels ("Filter" and "Map") in their navigation bar buttons while others had already been updated to use icons. This created an inconsistent user experience.
+
+## Solution Overview
+
+Updated the remaining text-based navigation bar buttons to use SF Symbols icons:
+- Filter button: `line.3.horizontal.decrease.circle` icon
+- Map button: `map` icon
+
+## Key Changes
+
+### 1. EventListViewController.swift (line 117)
+**Before:**
+```swift
+let filter = UIBarButtonItem(title: "Filter", style: .plain, target: self, action: #selector(filterButtonPressed(_:)))
+```
+
+**After:**
+```swift
+let filter = UIBarButtonItem(image: UIImage(systemName: "line.3.horizontal.decrease.circle"), style: .plain, target: self, action: #selector(filterButtonPressed(_:)))
+```
+
+### 2. MapButtonHelper.swift (line 18)
+**Before:**
+```swift
+let map = UIBarButtonItem(title: "Map", style: .plain) { [weak self] (button) in
+    self?.mapButtonPressed(button)
+}
+```
+
+**After:**
+```swift
+let map = UIBarButtonItem(image: UIImage(systemName: "map"), style: .plain) { [weak self] (button) in
+    self?.mapButtonPressed(button)
+}
+```
+
+## Technical Details
+
+### Files Modified
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/EventListViewController.swift`
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/MapButtonHelper.swift`
+
+### View Controllers Affected
+- **EventListViewController**: Now uses filter icon instead of text
+- **ObjectListViewController**: Uses MapButtonHelper protocol, now shows map icon
+- **NearbyViewController**: Uses MapButtonHelper protocol, now shows map icon
+- **FavoritesViewController**: Already had icons for both (no changes needed)
+- **ArtListViewController**: Already had filter icon (no changes needed)
+
+### Icon Choices
+- **Filter Icon**: `line.3.horizontal.decrease.circle` - A standard iOS filter icon showing horizontal lines with decreasing length
+- **Map Icon**: `map` - A standard iOS map icon
+
+## Context Preservation
+
+### Initial Investigation
+1. Found that EventListViewController was using text "Filter" for its filter button
+2. Found that MapButtonHelper protocol was using text "Map" for map buttons
+3. Discovered that FavoritesViewController and ArtListViewController had already been updated to use icons
+
+### Build Verification
+- Successfully built the project after changes using `xcodebuild`
+- Confirmed no compilation errors introduced
+- All view controllers now consistently use icons instead of text
+
+## Expected Outcomes
+
+After these changes:
+1. All navigation bar buttons for Filter and Map functionality use consistent icons
+2. Improved visual consistency across the app
+3. Better accessibility as icons are language-independent
+4. More modern appearance following iOS design guidelines
+
+## Completion Status
+
+✅ All tasks completed successfully:
+- Researched current implementation
+- Replaced text with icons in EventListViewController
+- Replaced text with icons in MapButtonHelper protocol
+- Verified build succeeds with changes

--- a/iBurn/EventListViewController.swift
+++ b/iBurn/EventListViewController.swift
@@ -114,7 +114,7 @@ private extension EventListViewController {
     }
     
     func setupFilterButton() {
-        let filter = UIBarButtonItem(title: "Filter", style: .plain, target: self, action: #selector(filterButtonPressed(_:)))
+        let filter = UIBarButtonItem(image: UIImage(systemName: "line.3.horizontal.decrease.circle"), style: .plain, target: self, action: #selector(filterButtonPressed(_:)))
         let loading = UIBarButtonItem(customView: self.loadingIndicator)
         self.navigationItem.rightBarButtonItems = [filter, loading]
     }

--- a/iBurn/MapButtonHelper.swift
+++ b/iBurn/MapButtonHelper.swift
@@ -15,7 +15,7 @@ protocol MapButtonHelper: NSObjectProtocol {
 
 extension MapButtonHelper where Self: UIViewController {
     func setupMapButton() {
-        let map = UIBarButtonItem(title: "Map", style: .plain) { [weak self] (button) in
+        let map = UIBarButtonItem(image: UIImage(systemName: "map"), style: .plain) { [weak self] (button) in
             self?.mapButtonPressed(button)
         }
         var buttons: [UIBarButtonItem] = navigationItem.rightBarButtonItems ?? []


### PR DESCRIPTION
## Summary
- Replace "Filter" text with `line.3.horizontal.decrease.circle` icon in EventListViewController
- Replace "Map" text with `map` icon in MapButtonHelper protocol  
- Ensures consistency across all view controllers - all navigation bar buttons now use SF Symbols icons instead of text

## Changes
- **EventListViewController**: Updated filter button to use icon instead of "Filter" text
- **MapButtonHelper protocol**: Updated map button to use icon instead of "Map" text
- This affects ObjectListViewController and NearbyViewController which use the MapButtonHelper protocol
- FavoritesViewController and ArtListViewController already had icons (no changes needed)

## Test Plan
- [x] Build succeeds without errors
- [ ] Filter button shows icon in Events tab
- [ ] Map button shows icon in all list views (Art, Camps, Events, Nearby, Favorites)
- [ ] Icons are properly tinted according to theme (light/dark mode)
- [ ] Buttons remain functional after changes

🤖 Generated with [Claude Code](https://claude.ai/code)