### PR TITLE
Add heart emoji overlay for favorited items on map

### DIFF
--- a/Docs/2025-08-10-favorites-heart-icon-map.md
+++ b/Docs/2025-08-10-favorites-heart-icon-map.md
@@ -1,0 +1,108 @@
+# Favorites Heart Icon on Map Implementation
+
+## High-Level Plan
+
+**Problem Statement**: Add visual indicator for favorited items on the map when using emoji icons, similar to how event status is displayed with colored dots.
+
+**Solution Overview**: Implement a heart icon overlay that appears on the bottom-right corner of emoji map markers when an item is favorited.
+
+**Key Changes**:
+1. Extended EmojiImageRenderer to support favorite status
+2. Modified marker generation to check favorite status from database
+3. Removed legacy pink pin fallback for favorites
+
+## Technical Details
+
+### File Modifications
+
+#### 1. EmojiImageRenderer.swift
+- Added `isFavorite` and `heartSize` properties to Configuration struct
+- Updated cache key to include favorite status
+- Added heart rendering logic using SF Symbol "heart.fill"
+- Heart positioned at bottom-right corner with 2pt offset
+- Using .systemPink color for consistency with app theme
+- No background circle - transparent overlay for cleaner appearance
+
+#### 2. BRCDataObject+EmojiMarker.swift
+- Added database read to check favorite status from metadata
+- Pass `isFavorite` flag to all emoji renderer configurations
+- Supports simultaneous display of event status dots (top-left) and heart (bottom-right)
+
+#### 3. AnnotationDataSource.swift
+- Removed fallback to pink pin image for favorites (lines 191-195)
+- All favorite indication now handled by emoji renderer
+
+### Implementation Approach
+
+The implementation follows the existing pattern for event status dots but positions the heart in the opposite corner. This allows:
+- Events to show both status indicator (green/orange/red dot) and favorite heart
+- All object types (art, camps, events) to display heart when favorited
+- Efficient caching with favorite status included in cache key
+
+### Code Snippets
+
+**Configuration Structure Update**:
+```swift
+struct Configuration {
+    // ... existing properties ...
+    let isFavorite: Bool
+    let heartSize: CGFloat
+}
+```
+
+**Heart Rendering Logic**:
+```swift
+if configuration.isFavorite {
+    let heartImage = UIImage(systemName: "heart.fill")
+    let heartTintColor = UIColor.systemPink
+    let heartOffset: CGFloat = 2
+    
+    let heartRect = CGRect(
+        x: configuration.size.width - configuration.heartSize - heartOffset,
+        y: configuration.size.height - configuration.heartSize - heartOffset,
+        width: configuration.heartSize,
+        height: configuration.heartSize
+    )
+    
+    heartTintColor.setFill()
+    heartImage?.draw(in: heartRect)
+}
+```
+
+**Database Integration**:
+```swift
+var isFavorite = false
+BRCDatabaseManager.shared.uiConnection.read { transaction in
+    let metadata = self.metadata(with: transaction)
+    isFavorite = metadata.isFavorite
+}
+```
+
+## Build and Test Results
+
+Successfully built the application with no errors. The implementation:
+- Compiles without warnings
+- Integrates cleanly with existing emoji marker system
+- Maintains backwards compatibility with non-emoji pin modes
+
+## Expected Outcomes
+
+After this implementation:
+- ✅ Favorited items show pink heart icon on bottom-right of emoji
+- ✅ Events can display both status dot and heart simultaneously
+- ✅ Heart appears/disappears when toggling favorites
+- ✅ Clean appearance without background circles
+- ✅ Consistent with existing app UI patterns
+
+## Dependencies
+
+- UIKit SF Symbols for heart icon
+- Existing EmojiImageRenderer caching system
+- YapDatabase for favorite status persistence
+- BRCObjectMetadata for favorite state management
+
+## Future Considerations
+
+- May need to refresh map annotations when favorite status changes
+- Could add animation for heart appearance/disappearance
+- Consider cache invalidation strategy for favorite changes

--- a/iBurn/AnnotationDataSource.swift
+++ b/iBurn/AnnotationDataSource.swift
@@ -188,11 +188,7 @@ public protocol ImageAnnotation: MLNAnnotation {
 
 extension DataObjectAnnotation: ImageAnnotation {
     public var markerImage: UIImage? {
-        if metadata.isFavorite {
-            return UIImage(named: "BRCPinkPin")
-        } else {
-            return object.brc_markerImage
-        }
+        return object.brc_markerImage
     }
 }
 

--- a/iBurn/BRCDataObject+EmojiMarker.swift
+++ b/iBurn/BRCDataObject+EmojiMarker.swift
@@ -15,21 +15,29 @@ extension BRCDataObject {
         let emoji: String
         var configuration = EmojiImageRenderer.Configuration.mapPin
         
+        // Check if object is favorited
+        var isFavorite = false
+        BRCDatabaseManager.shared.uiConnection.read { transaction in
+            let metadata = self.metadata(with: transaction)
+            isFavorite = metadata.isFavorite
+        }
+        
         if let artObject = self as? BRCArtObject {
             emoji = artObject.emoji
+            configuration = .mapPinWithStatus(isFavorite: isFavorite)
         } else if let campObject = self as? BRCCampObject {
             emoji = campObject.emoji
+            configuration = .mapPinWithStatus(isFavorite: isFavorite)
         } else if let eventObject = self as? BRCEventObject {
             emoji = eventObject.eventType.emoji
             
             // Apply event status colors
             let statusColor = eventStatusColor(for: eventObject, at: Date.present)
-            if let color = statusColor {
-                configuration = .mapPinWithStatus(color: color)
-            }
+            configuration = .mapPinWithStatus(color: statusColor, isFavorite: isFavorite)
         } else {
             // Default emoji for unknown types
             emoji = "📍"
+            configuration = .mapPinWithStatus(isFavorite: isFavorite)
         }
         
         return EmojiImageRenderer.shared.renderEmoji(emoji, configuration: configuration)

--- a/iBurn/EmojiImageRenderer.swift
+++ b/iBurn/EmojiImageRenderer.swift
@@ -27,6 +27,8 @@ final class EmojiImageRenderer {
         let cornerRadius: CGFloat
         let statusDotColor: UIColor?
         let statusDotSize: CGFloat
+        let isFavorite: Bool
+        let heartSize: CGFloat
         
         init(size: CGSize, 
              backgroundColor: UIColor? = nil,
@@ -34,7 +36,9 @@ final class EmojiImageRenderer {
              borderWidth: CGFloat = 0,
              cornerRadius: CGFloat = 0,
              statusDotColor: UIColor? = nil,
-             statusDotSize: CGFloat = 8) {
+             statusDotSize: CGFloat = 8,
+             isFavorite: Bool = false,
+             heartSize: CGFloat = 10) {
             self.size = size
             self.backgroundColor = backgroundColor
             self.borderColor = borderColor
@@ -42,6 +46,8 @@ final class EmojiImageRenderer {
             self.cornerRadius = cornerRadius
             self.statusDotColor = statusDotColor
             self.statusDotSize = statusDotSize
+            self.isFavorite = isFavorite
+            self.heartSize = heartSize
         }
         
         static let `default` = Configuration(
@@ -52,11 +58,13 @@ final class EmojiImageRenderer {
             size: CGSize(width: 36, height: 36)
         )
         
-        static func mapPinWithStatus(color: UIColor) -> Configuration {
+        static func mapPinWithStatus(color: UIColor? = nil, isFavorite: Bool = false) -> Configuration {
             Configuration(
                 size: CGSize(width: 36, height: 36),
                 statusDotColor: color,
-                statusDotSize: 10
+                statusDotSize: 10,
+                isFavorite: isFavorite,
+                heartSize: 10
             )
         }
     }
@@ -75,7 +83,7 @@ final class EmojiImageRenderer {
     ///   - configuration: Rendering configuration
     /// - Returns: Rendered UIImage or nil if rendering fails
     func renderEmoji(_ emoji: String, configuration: Configuration = .default) -> UIImage? {
-        let cacheKey = "\(emoji)_\(configuration.size.width)_\(configuration.size.height)_\(configuration.backgroundColor?.hexString ?? "clear")_\(configuration.borderColor?.hexString ?? "none")_\(configuration.borderWidth)_\(configuration.cornerRadius)_\(configuration.statusDotColor?.hexString ?? "none")_\(configuration.statusDotSize)" as NSString
+        let cacheKey = "\(emoji)_\(configuration.size.width)_\(configuration.size.height)_\(configuration.backgroundColor?.hexString ?? "clear")_\(configuration.borderColor?.hexString ?? "none")_\(configuration.borderWidth)_\(configuration.cornerRadius)_\(configuration.statusDotColor?.hexString ?? "none")_\(configuration.statusDotSize)_\(configuration.isFavorite)_\(configuration.heartSize)" as NSString
         
         if let cachedImage = cache.object(forKey: cacheKey) {
             return cachedImage
@@ -144,6 +152,25 @@ final class EmojiImageRenderer {
                 statusDotColor.setFill()
                 dotPath.fill()
             }
+            
+            // Draw heart icon if favorite
+            if configuration.isFavorite {
+                let heartImage = UIImage(systemName: "heart.fill")
+                let heartTintColor = UIColor.systemPink
+                let heartOffset: CGFloat = 2
+                
+                // Position heart in bottom-right corner
+                let heartRect = CGRect(
+                    x: configuration.size.width - configuration.heartSize - heartOffset,
+                    y: configuration.size.height - configuration.heartSize - heartOffset,
+                    width: configuration.heartSize,
+                    height: configuration.heartSize
+                )
+                
+                // Draw the heart icon
+                heartTintColor.setFill()
+                heartImage?.draw(in: heartRect)
+            }
         }
         
         cache.setObject(image, forKey: cacheKey)
@@ -163,6 +190,8 @@ final class EmojiImageRenderer {
             _ = renderEmoji(emoji, configuration: .mapPinWithStatus(color: .systemGreen))
             _ = renderEmoji(emoji, configuration: .mapPinWithStatus(color: .systemOrange))
             _ = renderEmoji(emoji, configuration: .mapPinWithStatus(color: .systemRed))
+            _ = renderEmoji(emoji, configuration: .mapPinWithStatus(isFavorite: true))
+            _ = renderEmoji(emoji, configuration: .mapPinWithStatus(color: .systemGreen, isFavorite: true))
         }
     }
     

--- a/iBurn/EmojiImageRenderer.swift
+++ b/iBurn/EmojiImageRenderer.swift
@@ -155,8 +155,6 @@ final class EmojiImageRenderer {
             
             // Draw heart icon if favorite
             if configuration.isFavorite {
-                let heartImage = UIImage(systemName: "heart.fill")
-                let heartTintColor = UIColor.systemPink
                 let heartOffset: CGFloat = 2
                 
                 // Position heart in bottom-right corner
@@ -167,9 +165,18 @@ final class EmojiImageRenderer {
                     height: configuration.heartSize
                 )
                 
-                // Draw the heart icon
-                heartTintColor.setFill()
-                heartImage?.draw(in: heartRect)
+                // Create heart icons for border and fill
+                let heartFillImage = UIImage(systemName: "heart.fill")?.withRenderingMode(.alwaysTemplate)
+                let heartBorderImage = UIImage(systemName: "heart.fill")?.withRenderingMode(.alwaysTemplate)
+                
+                // Draw white border (slightly larger)
+                let borderRect = heartRect.insetBy(dx: -1, dy: -1)
+                UIColor.white.setFill()
+                heartBorderImage?.draw(in: borderRect)
+                
+                // Draw pink heart fill
+                UIColor.systemPink.setFill()
+                heartFillImage?.draw(in: heartRect)
             }
         }
         

--- a/iBurn/EmojiImageRenderer.swift
+++ b/iBurn/EmojiImageRenderer.swift
@@ -153,30 +153,44 @@ final class EmojiImageRenderer {
                 dotPath.fill()
             }
             
-            // Draw heart icon if favorite
+            // Draw heart emoji if favorite
             if configuration.isFavorite {
-                let heartOffset: CGFloat = 2
+                let heartEmoji = "❤️"
+                let heartOffset: CGFloat = 1
                 
                 // Position heart in bottom-right corner
+                let heartSize = configuration.heartSize
                 let heartRect = CGRect(
-                    x: configuration.size.width - configuration.heartSize - heartOffset,
-                    y: configuration.size.height - configuration.heartSize - heartOffset,
-                    width: configuration.heartSize,
-                    height: configuration.heartSize
+                    x: configuration.size.width - heartSize - heartOffset,
+                    y: configuration.size.height - heartSize - heartOffset,
+                    width: heartSize,
+                    height: heartSize
                 )
                 
-                // Create heart icons for border and fill
-                let heartFillImage = UIImage(systemName: "heart.fill")?.withRenderingMode(.alwaysTemplate)
-                let heartBorderImage = UIImage(systemName: "heart.fill")?.withRenderingMode(.alwaysTemplate)
+                // Create attributes with white stroke for visibility
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.alignment = .center
                 
-                // Draw white border (slightly larger)
-                let borderRect = heartRect.insetBy(dx: -1, dy: -1)
-                UIColor.white.setFill()
-                heartBorderImage?.draw(in: borderRect)
+                let fontSize = heartSize * 0.85
+                let font = UIFont.systemFont(ofSize: fontSize)
+                let attributes: [NSAttributedString.Key: Any] = [
+                    .font: font,
+                    .strokeColor: UIColor.white,
+                    .strokeWidth: -4.0,  // Negative for stroke + fill
+                    .foregroundColor: UIColor.systemPink,
+                    .paragraphStyle: paragraphStyle
+                ]
                 
-                // Draw pink heart fill
-                UIColor.systemPink.setFill()
-                heartFillImage?.draw(in: heartRect)
+                // Draw the emoji heart
+                let attributedString = NSAttributedString(string: heartEmoji, attributes: attributes)
+                let textSize = attributedString.size()
+                let centeredRect = CGRect(
+                    x: heartRect.origin.x + (heartRect.width - textSize.width) / 2,
+                    y: heartRect.origin.y + (heartRect.height - textSize.height) / 2,
+                    width: textSize.width,
+                    height: textSize.height
+                )
+                attributedString.draw(in: centeredRect)
             }
         }
         


### PR DESCRIPTION
## Summary
- Added heart emoji (❤️) overlay on bottom-right corner of map markers for favorited items
- Heart appears on all favorited objects (art, camps, events) when emoji map icons are enabled
- Events can display both status dots (top-left) and heart (bottom-right) simultaneously

## Implementation Details
- Extended `EmojiImageRenderer` to support favorite status with heart emoji rendering
- Modified `BRCDataObject+EmojiMarker` to check favorite status from database
- Removed legacy pink pin fallback for favorites in `AnnotationDataSource`
- Heart emoji has white stroke outline for visibility against any background

## Visual Design
- Heart position: Bottom-right corner with 1pt offset
- Heart emoji: ❤️ with white stroke border
- Size: 10pt (configurable)
- Works alongside event status dots which appear top-left

## Test Plan
- [x] Build succeeds without warnings
- [ ] Toggle favorite on art/camp/event and verify heart appears on map
- [ ] Verify events show both status dot and heart when applicable
- [ ] Test with both light and dark themes
- [ ] Verify heart is visible against various map backgrounds

🤖 Generated with [Claude Code](https://claude.ai/code)