### PR TITLE
Add event type display to event detail screen

### DIFF
--- a/Docs/2025-08-10-event-type-detail-display.md
+++ b/Docs/2025-08-10-event-type-detail-display.md
@@ -1,0 +1,76 @@
+# 2025-08-10 Event Type Detail Display
+
+## High-Level Plan
+
+**Problem**: Event detail screen didn't show the event type, making it unclear what category of event users were viewing.
+
+**Solution**: Added event type display with emoji and descriptive text to the event detail screen, positioned prominently after the title.
+
+## Technical Details
+
+### Changes Made
+
+**File**: `iBurn/Detail/ViewModels/DetailViewModel.swift`
+
+**Location**: Line 388-390 in `generateEventCells()` method
+
+**Implementation**:
+```swift
+// Event type with emoji
+let eventTypeString = "\(event.eventType.emoji) \(event.eventType.displayString)"
+cells.append(.text(eventTypeString, style: .subtitle))
+```
+
+### Display Format
+
+The event type now appears as:
+- Format: `[emoji] [display string]`
+- Examples:
+  - "🎉 Gathering/Party"
+  - "🧑‍🏫 Class/Workshop" 
+  - "💃 Performance"
+  - "🔥 Fire/Spectacle"
+
+### Cell Order
+
+The event type appears in this order within event details:
+1. Image (if available)
+2. Title
+3. Description
+4. **Event Type (NEW)**
+5. Host relationship (camp/art)
+6. Next event from host
+7. Schedule
+8. Location
+9. Host description
+
+## Context Preservation
+
+### Event Type System
+- Event types are defined in `BRCEventObject.h` as an enum `BRCEventType`
+- Display strings and emojis are mapped in `BRCEventObject.swift` extensions
+- Each type has:
+  - Emoji representation (e.g., 🎉 for Party)
+  - Display string (e.g., "Gathering/Party")
+  - Visibility flag (some types are hidden)
+
+### Integration Points
+- Uses existing `.text` cell type with `.subtitle` style
+- Leverages BRCEventType extensions for display formatting
+- No new UI components required
+- Works with existing theme color system
+
+## Expected Outcomes
+
+Users viewing event details will now see:
+- Clear indication of event type at the top of details
+- Visual emoji representation for quick recognition
+- Descriptive text for accessibility and clarity
+- Consistent theming with rest of detail view
+
+## Testing Verification
+
+- Build completed successfully
+- Event type displays correctly with emoji and text
+- Cell positioning is logical and prominent
+- No UI layout issues introduced

--- a/Docs/2025-08-10-event-type-detail-display.md
+++ b/Docs/2025-08-10-event-type-detail-display.md
@@ -4,32 +4,63 @@
 
 **Problem**: Event detail screen didn't show the event type, making it unclear what category of event users were viewing.
 
-**Solution**: Added event type display with emoji and descriptive text to the event detail screen, positioned prominently after the title.
+**Solution**: Added event type as a dedicated section with header "EVENT TYPE", positioned before the host description for clear event categorization.
 
 ## Technical Details
 
 ### Changes Made
 
-**File**: `iBurn/Detail/ViewModels/DetailViewModel.swift`
-
-**Location**: Line 388-390 in `generateEventCells()` method
-
-**Implementation**:
+#### 1. Added Event Type Cell Case
+**File**: `iBurn/Detail/Models/DetailCellType.swift`
 ```swift
-// Event type with emoji
-let eventTypeString = "\(event.eventType.emoji) \(event.eventType.displayString)"
-cells.append(.text(eventTypeString, style: .subtitle))
+case eventType(BRCEventType)
 ```
+
+#### 2. Added Event Type to Event Cells
+**File**: `iBurn/Detail/ViewModels/DetailViewModel.swift`
+```swift
+// Event type section
+cells.append(.eventType(event.eventType))
+```
+Positioned after location, before host description.
+
+#### 3. Created DetailEventTypeCell Component
+**File**: `iBurn/Detail/Views/DetailView.swift`
+```swift
+struct DetailEventTypeCell: View {
+    let eventType: BRCEventType
+    @Environment(\.themeColors) var themeColors
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("EVENT TYPE")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(themeColors.detailColor)
+                .textCase(.uppercase)
+            
+            Text("\(eventType.emoji) \(eventType.displayString)")
+                .foregroundColor(themeColors.secondaryColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+```
+
+#### 4. Added Switch Cases
+- Added case handling in cell rendering switch
+- Added eventType to non-tappable cells list
 
 ### Display Format
 
-The event type now appears as:
-- Format: `[emoji] [display string]`
-- Examples:
+The event type now appears:
+- **Section Header**: "EVENT TYPE" in uppercase, caption font
+- **Content**: `[emoji] [display string]` in secondary color
+- **Style**: Consistent with other section headers (SCHEDULE, LANDMARK, etc.)
+- **Examples**:
   - "🎉 Gathering/Party"
-  - "🧑‍🏫 Class/Workshop" 
+  - "🧑‍🏫 Class/Workshop"
   - "💃 Performance"
-  - "🔥 Fire/Spectacle"
 
 ### Cell Order
 
@@ -37,12 +68,20 @@ The event type appears in this order within event details:
 1. Image (if available)
 2. Title
 3. Description
-4. **Event Type (NEW)**
-5. Host relationship (camp/art)
-6. Next event from host
-7. Schedule
-8. Location
+4. Host relationship (camp/art)
+5. Next event from host
+6. Schedule
+7. Location
+8. **EVENT TYPE (with section header)**
 9. Host description
+
+### Visual Consistency
+
+The implementation maintains consistency with other detail sections:
+1. Uses standard section header styling (uppercase, caption, semibold)
+2. Follows same VStack layout pattern as LANDMARK and SCHEDULE
+3. Uses theme colors appropriately (detailColor for header, secondaryColor for content)
+4. Proper spacing and alignment
 
 ## Context Preservation
 

--- a/iBurn/Detail/Models/DetailCellType.swift
+++ b/iBurn/Detail/Models/DetailCellType.swift
@@ -43,6 +43,7 @@ enum DetailCellType {
     case userNotes(String)
     case date(Date, format: String)
     case landmark(String)
+    case eventType(BRCEventType)
 }
 
 // MARK: - Supporting Types

--- a/iBurn/Detail/ViewModels/DetailViewModel.swift
+++ b/iBurn/Detail/ViewModels/DetailViewModel.swift
@@ -385,6 +385,10 @@ class DetailViewModel: ObservableObject {
     private func generateEventCells(_ event: BRCEventObject) -> [DetailCellType] {
         var cells: [DetailCellType] = []
         
+        // Event type with emoji
+        let eventTypeString = "\(event.eventType.emoji) \(event.eventType.displayString)"
+        cells.append(.text(eventTypeString, style: .subtitle))
+        
         // Host relationship (camp or art)
         var hostName: String?
         var hostId: String?

--- a/iBurn/Detail/ViewModels/DetailViewModel.swift
+++ b/iBurn/Detail/ViewModels/DetailViewModel.swift
@@ -385,10 +385,6 @@ class DetailViewModel: ObservableObject {
     private func generateEventCells(_ event: BRCEventObject) -> [DetailCellType] {
         var cells: [DetailCellType] = []
         
-        // Event type with emoji
-        let eventTypeString = "\(event.eventType.emoji) \(event.eventType.displayString)"
-        cells.append(.text(eventTypeString, style: .subtitle))
-        
         // Host relationship (camp or art)
         var hostName: String?
         var hostId: String?
@@ -429,6 +425,9 @@ class DetailViewModel: ObservableObject {
         // Location with embargo handling
         let locationValue = getLocationValue(for: event)
         cells.append(.playaAddress(locationValue, tappable: dataService.canShowLocation(for: event)))
+        
+        // Event type section
+        cells.append(.eventType(event.eventType))
         
         // Add host description if available
         if let hostDescription = getHostDescription(for: event) {

--- a/iBurn/Detail/Views/DetailView.swift
+++ b/iBurn/Detail/Views/DetailView.swift
@@ -227,6 +227,9 @@ struct DetailCellView: View {
             
         case .landmark(let landmark):
             DetailLandmarkCell(landmark: landmark)
+            
+        case .eventType(let eventType):
+            DetailEventTypeCell(eventType: eventType)
         }
     }
     
@@ -236,7 +239,7 @@ struct DetailCellView: View {
             return true
         case .playaAddress(_, let tappable):
             return tappable
-        case .text, .distance, .schedule, .date, .landmark:
+        case .text, .distance, .schedule, .date, .landmark, .eventType:
             return false
         case .image:
             return true
@@ -680,6 +683,25 @@ struct DetailLandmarkCell: View {
                     .foregroundColor(themeColors.secondaryColor)
                 Spacer()
             }
+        }
+    }
+}
+
+struct DetailEventTypeCell: View {
+    let eventType: BRCEventType
+    @Environment(\.themeColors) var themeColors
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("EVENT TYPE")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(themeColors.detailColor)
+                .textCase(.uppercase)
+            
+            Text("\(eventType.emoji) \(eventType.displayString)")
+                .foregroundColor(themeColors.secondaryColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds event type display to the event detail screen with proper section header
- Shows event type with emoji and descriptive text (e.g., "🎉 Gathering/Party")
- Positioned after location, before host description for logical information flow

## Changes
- Added new `eventType` case to `DetailCellType` enum
- Created `DetailEventTypeCell` SwiftUI view with "EVENT TYPE" section header
- Integrated event type display into event detail generation
- Consistent styling with other detail sections (SCHEDULE, LANDMARK, etc.)

## Visual Design
The event type section follows the app's existing design patterns:
- Uppercase section header in caption font
- Content displayed with emoji for quick recognition
- Uses theme colors appropriately (detailColor for header, secondaryColor for content)
- Maintains proper spacing and alignment with other sections

## Testing
- Built and tested successfully
- Event type displays correctly for all event types
- No UI layout issues
- Proper theme color integration

🤖 Generated with [Claude Code](https://claude.ai/code)