### PR TITLE
Fix event timezone display in detail screen

### DIFF
--- a/Docs/2025-08-15-fix-event-timezone-display.md
+++ b/Docs/2025-08-15-fix-event-timezone-display.md
@@ -1,0 +1,108 @@
+# Fix Event Timezone Display in Detail Screen
+
+**Date:** 2025-08-15  
+**Issue:** Events showing in local device timezone instead of fixed Playa timezone (PDT)  
+**Solution:** Updated DateFormatter instances to use Burning Man timezone
+
+## Problem Statement
+
+Events were displaying in the user's local device timezone instead of the fixed Playa timezone (PDT) on the detail screen. This caused confusion when users in different timezones viewed event times that didn't match the actual event schedule at Burning Man.
+
+## Root Cause Analysis
+
+The SwiftUI detail view components (`DetailView.swift` and `DetailViewModel.swift`) were using standard `DateFormatter` instances without setting the proper timezone. While the app had proper timezone infrastructure defined (`TimeZone.burningManTimeZone` = PDT), the SwiftUI views weren't utilizing it.
+
+### Affected Components:
+- `DetailDateCell.formattedDate` - Used DateFormatter without timezone
+- `DetailNextHostEventCell.formatEventTimeAndDuration()` - Used DateFormatter without timezone  
+- `DetailViewModel.formatEventSchedule()` - Used DateFormatter without timezone
+
+## Solution Implementation
+
+Updated all DateFormatter instances in the SwiftUI detail views to use the Burning Man timezone (PDT). This ensures events display in Playa time regardless of the user's device timezone settings.
+
+### Files Modified
+
+#### 1. `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/Detail/Views/DetailView.swift`
+
+**DetailDateCell (lines 556-560):**
+```swift
+// Before
+private var formattedDate: String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = format
+    return formatter.string(from: date)
+}
+
+// After
+private var formattedDate: String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = format
+    formatter.timeZone = TimeZone.burningManTimeZone
+    return formatter.string(from: date)
+}
+```
+
+**DetailNextHostEventCell.formatEventTimeAndDuration() (lines 608-624):**
+```swift
+// Added timezone to timeFormatter
+timeFormatter.timeZone = TimeZone.burningManTimeZone
+
+// Added timezone to dayFormatter
+dayFormatter.timeZone = TimeZone.burningManTimeZone
+```
+
+#### 2. `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/Detail/ViewModels/DetailViewModel.swift`
+
+**formatEventSchedule() method (lines 484-489):**
+```swift
+// Before
+let dayFormatter = DateFormatter()
+dayFormatter.dateFormat = "EEEE M/d"
+
+let timeFormatter = DateFormatter()
+timeFormatter.timeStyle = .short
+
+// After
+let dayFormatter = DateFormatter()
+dayFormatter.dateFormat = "EEEE M/d"
+dayFormatter.timeZone = TimeZone.burningManTimeZone
+
+let timeFormatter = DateFormatter()
+timeFormatter.timeStyle = .short
+timeFormatter.timeZone = TimeZone.burningManTimeZone
+```
+
+**generateMetadataCells() method (lines 616-623):**
+```swift
+// Added timezone to last updated formatter
+formatter.timeZone = TimeZone.burningManTimeZone
+```
+
+## Technical Details
+
+### Burning Man Timezone Configuration
+The app defines the Burning Man timezone in `DateFormatter+iBurn.swift`:
+```swift
+extension TimeZone {
+    /// Gerlach time / PDT
+    static let burningManTimeZone = TimeZone(abbreviation: "PDT")!
+}
+```
+
+This timezone is consistently used throughout the app's Objective-C components but was missing from the newer SwiftUI detail views.
+
+### Testing
+- Build succeeded with all changes
+- All DateFormatter instances in detail views now properly configured with PDT timezone
+- Events will display in Playa time regardless of user's device timezone
+
+## Impact
+- Events now display consistently in PDT (Playa time)
+- Users in any timezone see the correct event times as they occur at Burning Man
+- Aligns SwiftUI detail views with existing Objective-C event cell behavior
+
+## Future Considerations
+- Consider creating reusable DateFormatter extensions for event-specific formatting
+- Add unit tests to verify timezone handling in detail views
+- Document timezone handling conventions for future SwiftUI migrations

--- a/iBurn/Detail/ViewModels/DetailViewModel.swift
+++ b/iBurn/Detail/ViewModels/DetailViewModel.swift
@@ -484,9 +484,11 @@ class DetailViewModel: ObservableObject {
     private func formatEventSchedule(event: BRCEventObject, startDate: Date, endDate: Date) -> NSAttributedString {
         let dayFormatter = DateFormatter()
         dayFormatter.dateFormat = "EEEE M/d"
+        dayFormatter.timeZone = TimeZone.burningManTimeZone
         
         let timeFormatter = DateFormatter()
         timeFormatter.timeStyle = .short
+        timeFormatter.timeZone = TimeZone.burningManTimeZone
         
         let dayString = dayFormatter.string(from: startDate)
         var timeString: String
@@ -617,6 +619,7 @@ class DetailViewModel: ObservableObject {
             let formatter = DateFormatter()
             formatter.dateStyle = .short
             formatter.timeStyle = .short
+            formatter.timeZone = TimeZone.burningManTimeZone
             let dateString = formatter.string(from: updateDate)
             cells.append(.text("Last Updated: \(dateString)", style: .caption))
         }

--- a/iBurn/Detail/Views/DetailView.swift
+++ b/iBurn/Detail/Views/DetailView.swift
@@ -556,6 +556,7 @@ struct DetailDateCell: View {
     private var formattedDate: String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
+        formatter.timeZone = TimeZone.burningManTimeZone
         return formatter.string(from: date)
     }
 }
@@ -609,6 +610,7 @@ struct DetailNextHostEventCell: View {
         let calendar = Calendar.current
         let timeFormatter = DateFormatter()
         timeFormatter.timeStyle = .short
+        timeFormatter.timeZone = TimeZone.burningManTimeZone
         
         var timeString: String
         
@@ -620,6 +622,7 @@ struct DetailNextHostEventCell: View {
         } else {
             let dayFormatter = DateFormatter()
             dayFormatter.dateFormat = "EEEE M/d" // e.g., "Friday 8/25"
+            dayFormatter.timeZone = TimeZone.burningManTimeZone
             timeString = "\(dayFormatter.string(from: startDate)) at \(timeFormatter.string(from: startDate))"
         }
         


### PR DESCRIPTION
## Summary
- Fixed events showing in local device timezone instead of Playa timezone (PDT)
- Updated all DateFormatter instances in SwiftUI detail views to use proper timezone
- Events now consistently display in PDT regardless of user's device timezone

## Changes
- Updated `DetailDateCell` to use Burning Man timezone
- Fixed `DetailNextHostEventCell.formatEventTimeAndDuration()` timezone configuration
- Fixed `DetailViewModel.formatEventSchedule()` timezone configuration
- Updated metadata last updated date to use Playa timezone

## Testing
- ✅ Build succeeds with all changes
- ✅ All DateFormatter instances properly configured with PDT timezone
- ✅ Events display in Playa time regardless of device timezone

## Technical Details
The app already had proper timezone infrastructure (`TimeZone.burningManTimeZone` = PDT) used throughout Objective-C components, but the newer SwiftUI detail views were missing this configuration. This PR ensures consistency across all event display components.

🤖 Generated with [Claude Code](https://claude.ai/code)