### PR TITLE
Improve distance display: show feet under 1000ft, miles otherwise

### DIFF
--- a/Docs/2025-08-22-distance-display-improvement.md
+++ b/Docs/2025-08-22-distance-display-improvement.md
@@ -1,0 +1,66 @@
+# Distance Display Improvement
+
+**Date**: 2025-08-22
+**Feature**: Updated distance formatting in detail screen
+
+## High-Level Plan
+
+### Problem Statement
+The detail screen was displaying all distances in feet regardless of the value, which was not user-friendly for longer distances.
+
+### Solution Overview
+Updated the distance display logic to intelligently choose between feet and miles:
+- Distances under 1000 feet: Display in feet (e.g., "500 ft")
+- Distances 1000 feet and over: Display in miles (e.g., "1.2 mi")
+
+## Technical Details
+
+### File Modified
+- `/Users/chrisbal/Documents/Code/iBurn-iOS/iBurn/Detail/Views/DetailView.swift`
+
+### Changes Made
+Updated the `DetailDistanceCell` struct's `formattedDistance` computed property (lines 413-429):
+
+```swift
+private var formattedDistance: String {
+    let meters = Measurement(value: distance, unit: UnitLength.meters)
+    let feet = meters.converted(to: .feet)
+    let miles = meters.converted(to: .miles)
+    
+    let formatter = MeasurementFormatter()
+    formatter.unitStyle = .short
+    formatter.unitOptions = .providedUnit
+    
+    if feet.value < 1000 {
+        formatter.numberFormatter.maximumFractionDigits = 0
+        return formatter.string(from: feet)
+    } else {
+        formatter.numberFormatter.maximumFractionDigits = 1
+        return formatter.string(from: miles)
+    }
+}
+```
+
+### Key Implementation Details
+- Converts the source meters measurement to both feet and miles upfront
+- Uses conditional logic to determine which unit to display
+- Uses MeasurementFormatter consistently for both units
+- Sets appropriate decimal places: 0 for feet, 1 for miles
+- Maintains localization support through MeasurementFormatter
+
+## Context Preservation
+
+### User Request
+"i want the distance on the detail screen to be feet under 1000 ft, then just show miles after that."
+
+### Implementation Approach
+The user clarified that both units should use MeasurementFormatter for consistency. Rather than converting feet to miles when needed, we convert the source meters to both units and then select which to display.
+
+## Expected Outcomes
+- Distances under 1000 feet display as whole numbers in feet (e.g., "750 ft")
+- Distances 1000 feet and over display in miles with one decimal place (e.g., "1.2 mi")
+- Consistent formatting and localization through MeasurementFormatter
+- Improved user experience with more appropriate units for different distance ranges
+
+## Build Status
+✅ Build successful with no compilation errors

--- a/iBurn/Detail/Views/DetailView.swift
+++ b/iBurn/Detail/Views/DetailView.swift
@@ -413,13 +413,19 @@ struct DetailDistanceCell: View {
     private var formattedDistance: String {
         let meters = Measurement(value: distance, unit: UnitLength.meters)
         let feet = meters.converted(to: .feet)
+        let miles = meters.converted(to: .miles)
         
         let formatter = MeasurementFormatter()
         formatter.unitStyle = .short
         formatter.unitOptions = .providedUnit
-        formatter.numberFormatter.maximumFractionDigits = 0
         
-        return formatter.string(from: feet)
+        if feet.value < 1000 {
+            formatter.numberFormatter.maximumFractionDigits = 0
+            return formatter.string(from: feet)
+        } else {
+            formatter.numberFormatter.maximumFractionDigits = 1
+            return formatter.string(from: miles)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated distance display logic to use more appropriate units based on distance
- Shows feet for distances under 1000 ft, miles for 1000 ft and over
- Improves user experience with clearer distance information

## Changes
- Modified `DetailDistanceCell` in `DetailView.swift` to intelligently choose between feet and miles
- Distances under 1000 feet display as whole numbers (e.g., "750 ft")
- Distances 1000 feet and over display in miles with one decimal place (e.g., "1.2 mi")
- Uses `MeasurementFormatter` consistently for both units ensuring proper localization

## Test Plan
- [ ] Build the app and verify no compilation errors
- [ ] Open detail view for various locations
- [ ] Verify distances under 1000 ft show in feet
- [ ] Verify distances 1000 ft and over show in miles
- [ ] Check that formatting looks correct (units, decimal places)

🤖 Generated with [Claude Code](https://claude.ai/code)