### PR TITLE
Add mutant vehicle tag search via FTS5

### DIFF
--- a/Packages/PlayaDB/Sources/PlayaDB/Models/MutantVehicleObject.swift
+++ b/Packages/PlayaDB/Sources/PlayaDB/Models/MutantVehicleObject.swift
@@ -35,6 +35,7 @@ public struct MutantVehicleObject: DataObject, Codable, FetchableRecord, Mutable
         // MV-specific columns
         case artist
         case donationLink = "donation_link"
+        case tagsText = "tags_text"
     }
 
     // Use Columns as CodingKeys
@@ -51,6 +52,7 @@ public struct MutantVehicleObject: DataObject, Codable, FetchableRecord, Mutable
     public var description: String?
     public var artist: String?
     public var donationLink: URL?
+    public var tagsText: String?
 
     public init(
         uid: String,
@@ -61,7 +63,8 @@ public struct MutantVehicleObject: DataObject, Codable, FetchableRecord, Mutable
         hometown: String? = nil,
         description: String? = nil,
         artist: String? = nil,
-        donationLink: URL? = nil
+        donationLink: URL? = nil,
+        tagsText: String? = nil
     ) {
         self.uid = uid
         self.name = name
@@ -72,6 +75,7 @@ public struct MutantVehicleObject: DataObject, Codable, FetchableRecord, Mutable
         self.description = description
         self.artist = artist
         self.donationLink = donationLink
+        self.tagsText = tagsText
     }
 }
 
@@ -117,9 +121,10 @@ public extension MutantVehicleObject {
         []
     }
 
-    /// Associated tags (populated by the database layer)
-    var tags: [MutantVehicleTag] {
-        []
+    /// Tags as an array, split from the denormalized `tagsText` column
+    var tagsList: [String] {
+        guard let tagsText, !tagsText.isEmpty else { return [] }
+        return tagsText.components(separatedBy: " ").filter { !$0.isEmpty }
     }
 }
 

--- a/Packages/PlayaDB/Sources/PlayaDB/PlayaDBImpl.swift
+++ b/Packages/PlayaDB/Sources/PlayaDB/PlayaDBImpl.swift
@@ -152,7 +152,8 @@ internal class PlayaDBImpl: PlayaDB {
                     hometown TEXT,
                     description TEXT,
                     artist TEXT,
-                    donation_link TEXT
+                    donation_link TEXT,
+                    tags_text TEXT
                 )
             """)
 
@@ -355,6 +356,7 @@ internal class PlayaDBImpl: PlayaDB {
                 description,
                 artist,
                 hometown,
+                tags_text,
                 content=mv_objects,
                 content_rowid=rowid,
                 tokenize='porter unicode61'
@@ -364,8 +366,8 @@ internal class PlayaDBImpl: PlayaDB {
         // MV triggers
         try db.execute(sql: """
             CREATE TRIGGER IF NOT EXISTS mv_objects_ai AFTER INSERT ON mv_objects BEGIN
-                INSERT INTO mv_objects_fts(rowid, uid, name, description, artist, hometown)
-                VALUES (new.rowid, new.uid, new.name, new.description, new.artist, new.hometown);
+                INSERT INTO mv_objects_fts(rowid, uid, name, description, artist, hometown, tags_text)
+                VALUES (new.rowid, new.uid, new.name, new.description, new.artist, new.hometown, new.tags_text);
             END
         """)
 
@@ -378,8 +380,8 @@ internal class PlayaDBImpl: PlayaDB {
         try db.execute(sql: """
             CREATE TRIGGER IF NOT EXISTS mv_objects_au AFTER UPDATE ON mv_objects BEGIN
                 DELETE FROM mv_objects_fts WHERE rowid = old.rowid;
-                INSERT INTO mv_objects_fts(rowid, uid, name, description, artist, hometown)
-                VALUES (new.rowid, new.uid, new.name, new.description, new.artist, new.hometown);
+                INSERT INTO mv_objects_fts(rowid, uid, name, description, artist, hometown, tags_text)
+                VALUES (new.rowid, new.uid, new.name, new.description, new.artist, new.hometown, new.tags_text);
             END
         """)
     }
@@ -1521,6 +1523,7 @@ internal class PlayaDBImpl: PlayaDB {
 
                 for apiMV in apiMVObjects {
                     var mvObject = self.convertMutantVehicleObject(from: apiMV)
+                    mvObject.tagsText = apiMV.tags.isEmpty ? nil : apiMV.tags.joined(separator: " ")
                     try mvObject.insert(db)
 
                     for apiImage in apiMV.images {

--- a/Packages/PlayaDB/Tests/PlayaDBTests/PlayaDBImportTests.swift
+++ b/Packages/PlayaDB/Tests/PlayaDBTests/PlayaDBImportTests.swift
@@ -454,6 +454,31 @@ final class PlayaDBImportTests: XCTestCase {
                       "Search should find Dragon Wagon MV")
     }
 
+    func testMutantVehicleSearchByTag() async throws {
+        try await playaDB.importFromData(
+            artData: MockAPIData.artJSON,
+            campData: MockAPIData.campJSON,
+            eventData: MockAPIData.eventJSON,
+            mvData: MockAPIData.mutantVehicleJSON
+        )
+
+        // "Fire" is a tag on Dragon Wagon
+        let fireResults = try await playaDB.searchObjects("Fire")
+        XCTAssertTrue(fireResults.contains(where: { $0.uid == "a6BVI000000Xf1r3BC" }),
+                      "FTS should find Dragon Wagon by its 'Fire' tag")
+
+        // "Circular" is a tag on Moebius Omnibus
+        let circularResults = try await playaDB.searchObjects("Circular")
+        XCTAssertTrue(circularResults.contains(where: { $0.uid == "a6BVI000000Le0r2AC" }),
+                      "FTS should find Moebius Omnibus by its 'Circular' tag")
+
+        // Verify tagsText is populated
+        let mvs = try await playaDB.fetchMutantVehicles()
+        let dragonWagon = mvs.first(where: { $0.uid == "a6BVI000000Xf1r3BC" })
+        XCTAssertNotNil(dragonWagon?.tagsText)
+        XCTAssertEqual(dragonWagon?.tagsList.sorted(), ["Dragon", "Fire"])
+    }
+
     func testMutantVehicleFavorite() async throws {
         try await playaDB.importFromData(
             artData: MockAPIData.artJSON,

--- a/iBurn/DependencyContainer.swift
+++ b/iBurn/DependencyContainer.swift
@@ -154,7 +154,8 @@ class DependencyContainer {
                 mv.name.lowercased().contains(q) ||
                 mv.description?.lowercased().contains(q) == true ||
                 mv.artist?.lowercased().contains(q) == true ||
-                mv.hometown?.lowercased().contains(q) == true
+                mv.hometown?.lowercased().contains(q) == true ||
+                mv.tagsText?.lowercased().contains(q) == true
             },
             isDatabaseSeeded: { [mutantVehicleDataProvider] in
                 await mutantVehicleDataProvider.isDatabaseSeeded()

--- a/iBurn/Detail/ViewModels/DetailViewModel.swift
+++ b/iBurn/Detail/ViewModels/DetailViewModel.swift
@@ -857,6 +857,11 @@ class DetailViewModel: ObservableObject {
             cellTypes.append(.text(description, style: .body))
         }
 
+        let tags = mv.tagsList
+        if !tags.isEmpty {
+            cellTypes.append(.text(tags.joined(separator: " · "), style: .caption))
+        }
+
         if let artist = mv.artist, !artist.isEmpty {
             cellTypes.append(.text("Artist: \(artist)", style: .subtitle))
         }


### PR DESCRIPTION
## Summary
- Denormalize MV tags into a `tags_text` column on `mv_objects` so they're indexed by FTS5 for global search and available for client-side list filtering
- Display tags in MV detail view as a caption row (e.g. "Fire · Dragon")
- New `testMutantVehicleSearchByTag` test validates FTS finds MVs by tag name

## Test plan
- [ ] Global search: type a tag like "Fire" → Dragon Wagon MV appears in results
- [ ] MV list search: type a tag like "Circular" → Moebius Omnibus filters in
- [ ] MV detail view: tags displayed below description
- [ ] Existing tag filter (filter sheet) still works
- [ ] All 91 PlayaDB tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)