### PR TITLE
Add AI-powered search and assistant via Apple Foundation Models

### DIFF
--- a/Docs/2026-04-05-apple-foundation-models-search.md
+++ b/Docs/2026-04-05-apple-foundation-models-search.md
@@ -1,4 +1,4 @@
-# Apple Foundation Models: AI-Powered Search
+# Apple Foundation Models: AI-Powered Search & Assistant
 
 ## High-Level Plan
 
@@ -88,10 +88,36 @@ GlobalSearchViewModel
 - **Tests:** All iBurnTests pass
 - **Xcode version:** 26.4
 
+## AI Assistant (Second Commit)
+
+Expanded Foundation Models integration into a full AI assistant with three features:
+
+### New Tools Added
+- **GetFavoritesTool** — reads user's favorites as a "taste profile" for recommendations
+- **FetchUpcomingEventsTool** — time-aware event discovery (1-12 hours ahead)
+- **FetchNearbyObjectsTool** — location-aware search via GPS coordinates + MKCoordinateRegion
+
+### Three AI Features
+1. **For You** — recommends items based on favorited art/camps/events
+2. **Day Planner** — generates a time-ordered schedule mixing interests with discoveries
+3. **What's Nearby** — curates interesting nearby items prioritizing events starting soon
+
+### Architecture
+- `AIAssistantService` protocol extends `AISearchService` with `recommend()`, `planDay()`, `whatsNearby()`
+- Each method creates a fresh `LanguageModelSession` with tailored instructions and 3-5 tool subset
+- `AIAssistantView` + `AIAssistantViewModel` — SwiftUI view with segmented picker for features
+- Entry point: "AI Assistant" row in More screen (hidden when AI unavailable)
+
+### Files
+- `iBurn/AISearch/AIAssistantModels.swift` — `@Generable` response types + public result structs
+- `iBurn/AISearch/AIAssistantView.swift` — SwiftUI UI
+- `iBurn/AISearch/AIAssistantViewModel.swift` — drives the view, resolves UIDs to display objects
+- Modified: `AISearchService.swift`, `PlayaSearchTools.swift`, `DependencyContainer.swift`, `MoreViewController.swift`
+
 ## Remaining Work
 
 - Test on physical device with Apple Intelligence enabled
-- Consider adding AI search to individual list views (not just global search)
 - When mv-tag-search branch merges, add `tagsText` to `FetchMutantVehiclesTool` output
 - Consider custom adapter training with Burning Man-specific vocabulary
-- Add error handling UI if AI search times out
+- Add detail view navigation from AI assistant result rows
+- Add caching of AI results to avoid re-running on tab switches

--- a/Docs/2026-04-05-apple-foundation-models-search.md
+++ b/Docs/2026-04-05-apple-foundation-models-search.md
@@ -1,0 +1,97 @@
+# Apple Foundation Models: AI-Powered Search
+
+## High-Level Plan
+
+Add on-device AI-powered semantic search using Apple's Foundation Models framework (iOS 26+). The on-device LLM acts as a natural language router, calling PlayaDB search tools to find results that keyword-based FTS5 would miss (e.g., "art that shoots flames" finding items tagged "fire").
+
+**Approach:** Tool calling pattern -- expose PlayaDB fetch/search operations as `Tool` protocol conformances. The model decides which tools to call based on the user's natural language query, then returns structured results via guided generation (`@Generable`).
+
+**Fallback:** FTS5 keyword search remains the baseline. AI search is an enhancement that runs in parallel and augments FTS5 results. Gracefully absent on older devices.
+
+## Architecture
+
+```
+User query
+    |
+    v
+GlobalSearchViewModel
+    |
+    +-- FTS5 (immediate) --> results displayed
+    |
+    +-- AI Search (parallel, if available)
+        |
+        v
+    FoundationModelSearchService
+        |
+        v
+    LanguageModelSession + Tools
+        - SearchByKeywordTool (wraps playaDB.searchObjects)
+        - FetchArtTool (wraps playaDB.fetchArt with filter)
+        - FetchCampsTool (wraps playaDB.fetchCamps with filter)
+        - FetchMutantVehiclesTool (wraps playaDB.fetchMutantVehicles with filter)
+        |
+        v
+    Guided generation -> [AISearchResultItem] (uid + reason)
+        |
+        v
+    Fetch actual objects by UID -> merge into existing sections
+    AI-only results get sparkle badge in UI
+```
+
+## Technical Details
+
+### New Files
+
+#### `iBurn/AISearch/AISearchService.swift`
+- `AISearchResult` struct (uid + reason)
+- `AISearchService` protocol (`isAvailable`, `search(_:)`)
+- `FoundationModelSearchService` class (iOS 26+ only, `#if canImport(FoundationModels)`)
+- `AISearchServiceFactory` for conditional creation
+- `@Generable` structs: `AISearchResultItem`, `AISearchResponse`
+
+#### `iBurn/AISearch/PlayaSearchTools.swift`
+- `SearchByKeywordTool` -- wraps `playaDB.searchObjects()` (FTS5)
+- `FetchArtTool` -- wraps `playaDB.fetchArt(filter:)`
+- `FetchCampsTool` -- wraps `playaDB.fetchCamps(filter:)`
+- `FetchMutantVehiclesTool` -- wraps `playaDB.fetchMutantVehicles(filter:)`
+- All behind `#if canImport(FoundationModels)` and `@available(iOS 26, *)`
+- Uses `@preconcurrency import PlayaDB` for Sendable compatibility
+
+### Modified Files
+
+#### `iBurn/DependencyContainer.swift`
+- Added `aiSearchService` lazy property using `AISearchServiceFactory`
+- `makeGlobalSearchViewModel()` now passes `aiSearchService`
+
+#### `iBurn/ListView/GlobalSearchViewModel.swift`
+- Added `aiSearchService` dependency (optional)
+- Added `aiSuggestedUIDs` published set (tracks which results came from AI)
+- Added `isAISearching` published bool
+- After FTS5 results display, kicks off `runAISearch()` if AI is available
+- `mergeAIResults()` adds AI-discovered items into existing sections
+
+#### `iBurn/ListView/GlobalSearchView.swift`
+- Added sparkle icon overlay on AI-suggested result rows
+- Added "Finding more with AI..." progress indicator at bottom of results list
+
+## Key Decisions
+
+1. **App target, not PlayaDB package** -- PlayaDB targets iOS 16+, FoundationModels requires iOS 26+. AI search lives in the iBurn app target with availability guards.
+2. **`#if canImport` + `@available`** -- Compile-time gating (SDK availability) plus runtime gating (device capability). Builds on any Xcode, runs AI features only on capable devices.
+3. **4 tools** -- Stays within Apple's 3-5 tool recommendation for context window efficiency.
+4. **Parallel search** -- FTS5 results appear immediately; AI results augment after a brief delay. No degradation for non-AI devices.
+5. **Sparkle badge** -- Subtle `Image(systemName: "sparkles")` overlay to indicate AI-discovered results.
+
+## Build & Test Results
+
+- **Build:** 0 errors, 2 pre-existing warnings (not from this change)
+- **Tests:** All iBurnTests pass
+- **Xcode version:** 26.4
+
+## Remaining Work
+
+- Test on physical device with Apple Intelligence enabled
+- Consider adding AI search to individual list views (not just global search)
+- When mv-tag-search branch merges, add `tagsText` to `FetchMutantVehiclesTool` output
+- Consider custom adapter training with Burning Man-specific vocabulary
+- Add error handling UI if AI search times out

--- a/Packages/PlayaDB/Tests/PlayaDBTests/PlayaDBRealDataTests.swift
+++ b/Packages/PlayaDB/Tests/PlayaDBTests/PlayaDBRealDataTests.swift
@@ -236,6 +236,158 @@ final class PlayaDBRealDataTests: XCTestCase {
         XCTAssertTrue(isFavorite, "First art object should be marked as favorite")
     }
 
+    // MARK: - AI Search Scenario Tests
+    //
+    // These tests validate that the PlayaDB queries underlying the AI search tools
+    // produce meaningful results for various search patterns. The on-device Foundation
+    // Model would call these same queries via Tool wrappers.
+
+    func testSearchByKeyword_MultipleTypes() async throws {
+        try await importAllRealData()
+
+        // A keyword search should return results across multiple object types
+        let results = try await playaDB.searchObjects("fire")
+        let types = Set(results.map { $0.objectType })
+
+        XCTAssertGreaterThan(results.count, 0, "Should find results for 'fire'")
+        print("'fire' search: \(results.count) results across types: \(types)")
+
+        // Verify result objects have names (tool would format these for the model)
+        for result in results.prefix(5) {
+            XCTAssertFalse(result.name.isEmpty, "Each result should have a name")
+            XCTAssertFalse(result.uid.isEmpty, "Each result should have a uid")
+        }
+    }
+
+    func testSearchByKeyword_SingleWordQueries() async throws {
+        try await importAllRealData()
+
+        // Test various single-word queries that an AI model might decompose from natural language
+        let queries = ["music", "dance", "yoga", "art", "temple", "burn"]
+        for query in queries {
+            let results = try await playaDB.searchObjects(query)
+            print("'\(query)' search: \(results.count) results")
+            // Most common festival terms should find something
+            XCTAssertGreaterThan(results.count, 0, "Should find results for '\(query)'")
+        }
+    }
+
+    func testFetchArtWithFilter_KeywordSearch() async throws {
+        try await importAllRealData()
+
+        // Simulate what FetchArtTool would do
+        var filter = ArtFilter.all
+        filter.searchText = "temple"
+        let results = try await playaDB.fetchArt(filter: filter)
+
+        XCTAssertGreaterThan(results.count, 0, "Should find art matching 'temple'")
+        for art in results {
+            XCTAssertFalse(art.name.isEmpty)
+            XCTAssertFalse(art.uid.isEmpty)
+        }
+        print("Art filter 'temple': \(results.count) results")
+    }
+
+    func testFetchCampsWithFilter_KeywordSearch() async throws {
+        try await importAllRealData()
+
+        // Simulate what FetchCampsTool would do
+        var filter = CampFilter.all
+        filter.searchText = "music"
+        let results = try await playaDB.fetchCamps(filter: filter)
+
+        XCTAssertGreaterThan(results.count, 0, "Should find camps matching 'music'")
+        for camp in results {
+            XCTAssertFalse(camp.name.isEmpty)
+            XCTAssertFalse(camp.uid.isEmpty)
+        }
+        print("Camp filter 'music': \(results.count) results")
+    }
+
+    func testFetchMVsWithFilter_KeywordSearch() async throws {
+        try await importAllRealData()
+
+        // Simulate what FetchMutantVehiclesTool would do
+        var filter = MutantVehicleFilter.all
+        filter.searchText = "dragon"
+        let results = try await playaDB.fetchMutantVehicles(filter: filter)
+
+        XCTAssertGreaterThan(results.count, 0, "Should find MVs matching 'dragon'")
+        for mv in results {
+            XCTAssertFalse(mv.name.isEmpty)
+            XCTAssertFalse(mv.uid.isEmpty)
+        }
+        print("MV filter 'dragon': \(results.count) results")
+    }
+
+    func testToolOutputFormatting_ResultsAreConcise() async throws {
+        try await importAllRealData()
+
+        // Verify that search results can be formatted concisely for the on-device model's
+        // 4096 token context window. Each result should be expressible in ~100 chars.
+        let results = try await playaDB.searchObjects("camp")
+        let formatted = results.prefix(15).map { obj in
+            "\(obj.objectType.rawValue): \(obj.name) (uid: \(obj.uid))"
+        }.joined(separator: "\n")
+
+        // 15 results formatted should fit comfortably in the context window
+        XCTAssertLessThan(formatted.count, 3000, "Formatted results should be concise enough for context window")
+        print("Formatted output (\(formatted.count) chars):\n\(formatted)")
+    }
+
+    func testSearchObjectsFetchByUID_Roundtrip() async throws {
+        try await importAllRealData()
+
+        // Simulate the AI search flow: search -> get UIDs -> fetch individual objects
+        let searchResults = try await playaDB.searchObjects("fire")
+        XCTAssertGreaterThan(searchResults.count, 0)
+
+        // For each result, verify we can fetch it back by UID (as mergeAIResults does)
+        for result in searchResults.prefix(5) {
+            switch result.objectType {
+            case .art:
+                let fetched = try await playaDB.fetchArt(uid: result.uid)
+                XCTAssertNotNil(fetched, "Should fetch art by uid: \(result.uid)")
+                XCTAssertEqual(fetched?.name, result.name)
+            case .camp:
+                let fetched = try await playaDB.fetchCamp(uid: result.uid)
+                XCTAssertNotNil(fetched, "Should fetch camp by uid: \(result.uid)")
+                XCTAssertEqual(fetched?.name, result.name)
+            case .event:
+                let fetched = try await playaDB.fetchEvent(uid: result.uid)
+                XCTAssertNotNil(fetched, "Should fetch event by uid: \(result.uid)")
+                XCTAssertEqual(fetched?.name, result.name)
+            case .mutantVehicle:
+                let fetched = try await playaDB.fetchMutantVehicle(uid: result.uid)
+                XCTAssertNotNil(fetched, "Should fetch MV by uid: \(result.uid)")
+                XCTAssertEqual(fetched?.name, result.name)
+            }
+        }
+    }
+
+    func testMultipleToolCallScenario_DecomposedQuery() async throws {
+        try await importAllRealData()
+
+        // Simulate what the AI model would do for "interactive fire art":
+        // 1. Call searchByKeyword("fire") for broad results
+        let fireResults = try await playaDB.searchObjects("fire")
+
+        // 2. Call fetchArt(keyword: "interactive") for targeted art search
+        var artFilter = ArtFilter.all
+        artFilter.searchText = "interactive"
+        let interactiveArt = try await playaDB.fetchArt(filter: artFilter)
+
+        // 3. Both calls should return results
+        XCTAssertGreaterThan(fireResults.count, 0, "Should find results for 'fire'")
+        XCTAssertGreaterThan(interactiveArt.count, 0, "Should find interactive art")
+
+        // 4. The model would intersect/rank these -- verify UIDs are usable
+        let fireUIDs = Set(fireResults.map { $0.uid })
+        let interactiveUIDs = Set(interactiveArt.map { $0.uid })
+        let overlap = fireUIDs.intersection(interactiveUIDs)
+        print("'fire' results: \(fireResults.count), 'interactive' art: \(interactiveArt.count), overlap: \(overlap.count)")
+    }
+
     // MARK: - Query Extension Performance Tests
 
     func testQueryExtensions_OrderedByNamePerformance() async throws {

--- a/iBurn/AISearch/AIAssistantModels.swift
+++ b/iBurn/AISearch/AIAssistantModels.swift
@@ -1,0 +1,98 @@
+//
+//  AIAssistantModels.swift
+//  iBurn
+//
+//  Created by Claude Code on 4/5/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Public Result Types (always available)
+
+/// A recommendation from the AI assistant
+struct AIRecommendation: Sendable, Identifiable {
+    let uid: String
+    let reason: String
+    var id: String { uid }
+}
+
+/// A scheduled item in an AI-generated day plan
+struct AIScheduleItem: Sendable, Identifiable {
+    let uid: String
+    let startTime: String
+    let reason: String
+    var id: String { uid }
+}
+
+/// An AI-generated day plan
+struct AIDayPlan: Sendable {
+    let schedule: [AIScheduleItem]
+    let summary: String
+}
+
+/// A nearby highlight from the AI assistant
+struct AINearbyHighlight: Sendable, Identifiable {
+    let uid: String
+    let reason: String
+    var id: String { uid }
+}
+
+// MARK: - Generable Types (iOS 26+ only)
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+@available(iOS 26, *)
+@Generable
+struct GenerableRecommendation {
+    @Guide(description: "Object uid")
+    var uid: String
+    @Guide(description: "Why this matches the user's taste, under 12 words")
+    var reason: String
+}
+
+@available(iOS 26, *)
+@Generable
+struct GenerableRecommendationResponse {
+    @Guide(description: "Recommended items", .count(3...8))
+    var recommendations: [GenerableRecommendation]
+}
+
+@available(iOS 26, *)
+@Generable
+struct GenerableScheduleItem {
+    @Guide(description: "Event uid")
+    var uid: String
+    @Guide(description: "Start time like '2:00 PM'")
+    var startTime: String
+    @Guide(description: "Why this fits the plan, under 12 words")
+    var reason: String
+}
+
+@available(iOS 26, *)
+@Generable
+struct GenerableDayPlanResponse {
+    @Guide(description: "Events ordered by time", .count(3...10))
+    var schedule: [GenerableScheduleItem]
+    @Guide(description: "One-sentence summary of the day theme")
+    var summary: String
+}
+
+@available(iOS 26, *)
+@Generable
+struct GenerableNearbyHighlight {
+    @Guide(description: "Object uid")
+    var uid: String
+    @Guide(description: "Why this is interesting right now, under 12 words")
+    var reason: String
+}
+
+@available(iOS 26, *)
+@Generable
+struct GenerableNearbyResponse {
+    @Guide(description: "Nearby highlights, most interesting first", .count(2...8))
+    var highlights: [GenerableNearbyHighlight]
+}
+
+#endif

--- a/iBurn/AISearch/AIAssistantView.swift
+++ b/iBurn/AISearch/AIAssistantView.swift
@@ -1,0 +1,237 @@
+//
+//  AIAssistantView.swift
+//  iBurn
+//
+//  Created by Claude Code on 4/5/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+
+import SwiftUI
+import PlayaDB
+
+struct AIAssistantView: View {
+    @ObservedObject var viewModel: AIAssistantViewModel
+    @Environment(\.themeColors) var themeColors
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Feature picker
+            Picker("Feature", selection: $viewModel.selectedFeature) {
+                ForEach(AIAssistantViewModel.Feature.allCases) { feature in
+                    Text(feature.rawValue).tag(feature)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+            .onChange(of: viewModel.selectedFeature) { _ in
+                viewModel.loadCurrentFeature()
+            }
+
+            // Content
+            if viewModel.isLoading {
+                Spacer()
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .scaleEffect(1.2)
+                    Text("AI is exploring the playa...")
+                        .font(.subheadline)
+                        .foregroundColor(themeColors.secondaryColor)
+                }
+                Spacer()
+            } else if let error = viewModel.errorMessage {
+                Spacer()
+                VStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 36))
+                        .foregroundColor(.orange)
+                    Text(error)
+                        .font(.subheadline)
+                        .foregroundColor(themeColors.secondaryColor)
+                        .multilineTextAlignment(.center)
+                    Button("Try Again") {
+                        viewModel.loadCurrentFeature()
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding()
+                Spacer()
+            } else {
+                featureContent
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var featureContent: some View {
+        switch viewModel.selectedFeature {
+        case .forYou:
+            recommendationsList
+        case .dayPlan:
+            dayPlanView
+        case .nearby:
+            nearbyList
+        }
+    }
+
+    // MARK: - For You
+
+    private var recommendationsList: some View {
+        Group {
+            if viewModel.recommendations.isEmpty {
+                emptyState(
+                    icon: "sparkles",
+                    title: "Personalized Recommendations",
+                    subtitle: "Favorite some art, camps, or events first, then AI will suggest similar things you might enjoy."
+                )
+            } else {
+                List(viewModel.recommendations) { rec in
+                    aiItemRow(uid: rec.uid, reason: rec.reason)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Day Plan
+
+    private var dayPlanView: some View {
+        Group {
+            if let plan = viewModel.dayPlan, !plan.schedule.isEmpty {
+                List {
+                    if !plan.summary.isEmpty {
+                        Section {
+                            Text(plan.summary)
+                                .font(.subheadline)
+                                .foregroundColor(themeColors.secondaryColor)
+                        }
+                    }
+                    Section(header: Text("Schedule")) {
+                        ForEach(plan.schedule) { item in
+                            HStack(alignment: .top, spacing: 12) {
+                                Text(item.startTime)
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(themeColors.detailColor)
+                                    .frame(width: 60, alignment: .trailing)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    if let resolved = viewModel.resolvedObjects[item.uid] {
+                                        Text(resolved.name)
+                                            .font(.headline)
+                                            .foregroundColor(themeColors.primaryColor)
+                                    } else {
+                                        Text(item.uid)
+                                            .font(.headline)
+                                            .foregroundColor(themeColors.primaryColor)
+                                    }
+                                    Text(item.reason)
+                                        .font(.caption)
+                                        .foregroundColor(themeColors.secondaryColor)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            } else {
+                emptyState(
+                    icon: "calendar.badge.clock",
+                    title: "AI Day Planner",
+                    subtitle: "Get a personalized schedule based on your interests and what's happening today."
+                )
+            }
+        }
+    }
+
+    // MARK: - Nearby
+
+    private var nearbyList: some View {
+        Group {
+            if viewModel.nearbyHighlights.isEmpty {
+                emptyState(
+                    icon: "location.circle",
+                    title: "What's Nearby",
+                    subtitle: "Discover interesting art, camps, and events near your current location."
+                )
+            } else {
+                List(viewModel.nearbyHighlights) { highlight in
+                    aiItemRow(uid: highlight.uid, reason: highlight.reason)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Shared Components
+
+    private func aiItemRow(uid: String, reason: String) -> some View {
+        HStack(spacing: 12) {
+            if let resolved = viewModel.resolvedObjects[uid] {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Text(typeEmoji(resolved.objectType))
+                        Text(resolved.name)
+                            .font(.headline)
+                            .foregroundColor(themeColors.primaryColor)
+                            .lineLimit(1)
+                    }
+                    if let subtitle = resolved.subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundColor(themeColors.detailColor)
+                            .lineLimit(1)
+                    }
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundColor(themeColors.secondaryColor)
+                        .lineLimit(2)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(uid)
+                        .font(.headline)
+                        .foregroundColor(themeColors.primaryColor)
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundColor(themeColors.secondaryColor)
+                }
+            }
+            Spacer(minLength: 0)
+            Image(systemName: "sparkles")
+                .font(.caption2)
+                .foregroundStyle(.purple)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func emptyState(icon: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: icon)
+                .font(.system(size: 48))
+                .foregroundColor(themeColors.detailColor)
+            Text(title)
+                .font(.headline)
+                .foregroundColor(themeColors.primaryColor)
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundColor(themeColors.secondaryColor)
+                .multilineTextAlignment(.center)
+            Button("Generate") {
+                viewModel.loadCurrentFeature()
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func typeEmoji(_ type: DataObjectType) -> String {
+        switch type {
+        case .art: return "🎨"
+        case .camp: return "⛺"
+        case .event: return "📅"
+        case .mutantVehicle: return "🚗"
+        }
+    }
+}

--- a/iBurn/AISearch/AIAssistantViewModel.swift
+++ b/iBurn/AISearch/AIAssistantViewModel.swift
@@ -1,0 +1,133 @@
+//
+//  AIAssistantViewModel.swift
+//  iBurn
+//
+//  Created by Claude Code on 4/5/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+import PlayaDB
+
+@MainActor
+final class AIAssistantViewModel: ObservableObject {
+
+    enum Feature: String, CaseIterable, Identifiable {
+        case forYou = "For You"
+        case dayPlan = "Day Plan"
+        case nearby = "Nearby"
+        var id: String { rawValue }
+    }
+
+    // MARK: - Published State
+
+    @Published var selectedFeature: Feature = .forYou
+    @Published var recommendations: [AIRecommendation] = []
+    @Published var dayPlan: AIDayPlan?
+    @Published var nearbyHighlights: [AINearbyHighlight] = []
+
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    /// Resolved objects for display (uid -> name, type, etc.)
+    @Published var resolvedObjects: [String: ResolvedItem] = [:]
+
+    struct ResolvedItem: Identifiable {
+        let uid: String
+        let name: String
+        let objectType: DataObjectType
+        let subtitle: String?
+        var id: String { uid }
+    }
+
+    // MARK: - Dependencies
+
+    private let aiService: AIAssistantService
+    private let playaDB: PlayaDB
+    private let locationProvider: LocationProvider
+
+    private var loadTask: Task<Void, Never>?
+
+    init(aiService: AIAssistantService, playaDB: PlayaDB, locationProvider: LocationProvider) {
+        self.aiService = aiService
+        self.playaDB = playaDB
+        self.locationProvider = locationProvider
+    }
+
+    // MARK: - Actions
+
+    func loadCurrentFeature() {
+        loadTask?.cancel()
+        isLoading = true
+        errorMessage = nil
+
+        loadTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                switch self.selectedFeature {
+                case .forYou:
+                    let results = try await self.aiService.recommend()
+                    guard !Task.isCancelled else { return }
+                    await self.resolveUIDs(results.map(\.uid))
+                    self.recommendations = results
+
+                case .dayPlan:
+                    let plan = try await self.aiService.planDay(
+                        date: Date(),
+                        location: self.locationProvider.currentLocation
+                    )
+                    guard !Task.isCancelled else { return }
+                    await self.resolveUIDs(plan.schedule.map(\.uid))
+                    self.dayPlan = plan
+
+                case .nearby:
+                    guard let location = self.locationProvider.currentLocation else {
+                        self.errorMessage = "Location not available. Enable location services to use this feature."
+                        self.isLoading = false
+                        return
+                    }
+                    let highlights = try await self.aiService.whatsNearby(location: location)
+                    guard !Task.isCancelled else { return }
+                    await self.resolveUIDs(highlights.map(\.uid))
+                    self.nearbyHighlights = highlights
+                }
+                self.isLoading = false
+            } catch is CancellationError {
+                // Ignored
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.errorMessage = "AI is thinking too hard. Try again."
+                self.isLoading = false
+                print("AI Assistant error: \(error)")
+            }
+        }
+    }
+
+    /// Fetch actual objects from PlayaDB to get display names
+    private func resolveUIDs(_ uids: [String]) async {
+        for uid in uids where resolvedObjects[uid] == nil {
+            if let art = try? await playaDB.fetchArt(uid: uid) {
+                resolvedObjects[uid] = ResolvedItem(
+                    uid: uid, name: art.name, objectType: .art,
+                    subtitle: art.artist
+                )
+            } else if let camp = try? await playaDB.fetchCamp(uid: uid) {
+                resolvedObjects[uid] = ResolvedItem(
+                    uid: uid, name: camp.name, objectType: .camp,
+                    subtitle: camp.hometown
+                )
+            } else if let event = try? await playaDB.fetchEvent(uid: uid) {
+                resolvedObjects[uid] = ResolvedItem(
+                    uid: uid, name: event.name, objectType: .event,
+                    subtitle: event.eventTypeLabel
+                )
+            } else if let mv = try? await playaDB.fetchMutantVehicle(uid: uid) {
+                resolvedObjects[uid] = ResolvedItem(
+                    uid: uid, name: mv.name, objectType: .mutantVehicle,
+                    subtitle: mv.artist
+                )
+            }
+        }
+    }
+}

--- a/iBurn/AISearch/AISearchService.swift
+++ b/iBurn/AISearch/AISearchService.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreLocation
 @preconcurrency import PlayaDB
 
 /// Result from AI-powered semantic search
@@ -24,12 +25,24 @@ protocol AISearchService: Sendable {
     func search(_ query: String) async throws -> [AISearchResult]
 }
 
+/// Extended protocol for AI assistant features (recommendations, day planner, nearby)
+protocol AIAssistantService: AISearchService {
+    /// Recommend items based on user's favorites
+    func recommend() async throws -> [AIRecommendation]
+
+    /// Generate a day plan for a specific date
+    func planDay(date: Date, location: CLLocation?) async throws -> AIDayPlan
+
+    /// Find interesting things happening nearby right now
+    func whatsNearby(location: CLLocation) async throws -> [AINearbyHighlight]
+}
+
 #if canImport(FoundationModels)
 import FoundationModels
 
-/// AI search implementation using Apple Foundation Models (iOS 26+)
+/// AI search and assistant implementation using Apple Foundation Models (iOS 26+)
 @available(iOS 26, *)
-final class FoundationModelSearchService: AISearchService {
+final class FoundationModelSearchService: AIAssistantService {
     private let playaDB: PlayaDB
 
     var isAvailable: Bool {
@@ -39,6 +52,8 @@ final class FoundationModelSearchService: AISearchService {
     init(playaDB: PlayaDB) {
         self.playaDB = playaDB
     }
+
+    // MARK: - Search
 
     func search(_ query: String) async throws -> [AISearchResult] {
         guard isAvailable else { return [] }
@@ -70,6 +85,119 @@ final class FoundationModelSearchService: AISearchService {
             AISearchResult(uid: $0.uid, reason: $0.reason)
         }
     }
+
+    // MARK: - Recommendations
+
+    func recommend() async throws -> [AIRecommendation] {
+        guard isAvailable else { return [] }
+
+        let tools: [any Tool] = [
+            GetFavoritesTool(playaDB: playaDB),
+            SearchByKeywordTool(playaDB: playaDB),
+            FetchArtTool(playaDB: playaDB),
+            FetchCampsTool(playaDB: playaDB),
+            FetchMutantVehiclesTool(playaDB: playaDB),
+        ]
+
+        let session = LanguageModelSession(
+            tools: tools,
+            instructions: """
+                You are a recommendation engine for a Burning Man festival guide. \
+                First call getFavorites to see what the user likes. Analyze the themes, \
+                types, and keywords in their favorites. Then search for similar items \
+                they haven't favorited yet. Return diverse recommendations across types.
+                """
+        )
+
+        let response = try await session.respond(
+            to: Prompt("What should I check out based on my favorites?"),
+            generating: GenerableRecommendationResponse.self
+        )
+
+        return response.content.recommendations.map {
+            AIRecommendation(uid: $0.uid, reason: $0.reason)
+        }
+    }
+
+    // MARK: - Day Planner
+
+    func planDay(date: Date, location: CLLocation?) async throws -> AIDayPlan {
+        guard isAvailable else { return AIDayPlan(schedule: [], summary: "") }
+
+        var tools: [any Tool] = [
+            GetFavoritesTool(playaDB: playaDB),
+            FetchUpcomingEventsTool(playaDB: playaDB),
+        ]
+        if location != nil {
+            tools.append(FetchNearbyObjectsTool(playaDB: playaDB))
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, MMMM d"
+        formatter.timeZone = TimeZone(identifier: "America/Los_Angeles")
+        let dayString = formatter.string(from: date)
+
+        var prompt = "Plan my day for \(dayString) at Burning Man."
+        if let loc = location {
+            prompt += " I'm currently at GPS \(loc.coordinate.latitude), \(loc.coordinate.longitude)."
+        }
+
+        let session = LanguageModelSession(
+            tools: tools,
+            instructions: """
+                You are a day planner for Burning Man. Check the user's favorites to \
+                understand their interests. Find upcoming events that match. Create a \
+                schedule ordered by time. Mix familiar interests with new discoveries. \
+                Consider walk time between locations (~10 min across playa).
+                """
+        )
+
+        let response = try await session.respond(
+            to: Prompt(prompt),
+            generating: GenerableDayPlanResponse.self
+        )
+
+        let schedule = response.content.schedule.map {
+            AIScheduleItem(uid: $0.uid, startTime: $0.startTime, reason: $0.reason)
+        }
+        return AIDayPlan(schedule: schedule, summary: response.content.summary)
+    }
+
+    // MARK: - What's Nearby
+
+    func whatsNearby(location: CLLocation) async throws -> [AINearbyHighlight] {
+        guard isAvailable else { return [] }
+
+        let tools: [any Tool] = [
+            GetFavoritesTool(playaDB: playaDB),
+            FetchUpcomingEventsTool(playaDB: playaDB),
+            FetchNearbyObjectsTool(playaDB: playaDB),
+        ]
+
+        let session = LanguageModelSession(
+            tools: tools,
+            instructions: """
+                You are a Burning Man guide. Find the most interesting things near \
+                the user right now. Check their favorites to understand preferences. \
+                Prioritize: events starting soon, art matching their taste, and camps \
+                they'd enjoy. Highlight why each item is worth visiting right now.
+                """
+        )
+
+        let prompt = """
+            What's interesting near me? I'm at GPS \
+            \(location.coordinate.latitude), \(location.coordinate.longitude).
+            """
+
+        let response = try await session.respond(
+            to: Prompt(prompt),
+            generating: GenerableNearbyResponse.self
+        )
+
+        return response.content.highlights.map {
+            AINearbyHighlight(uid: $0.uid, reason: $0.reason)
+        }
+    }
 }
 
 @available(iOS 26, *)
@@ -90,10 +218,21 @@ struct AISearchResponse {
 
 #endif
 
-/// Factory for creating the appropriate AI search service
+/// Factory for creating the appropriate AI service
 enum AISearchServiceFactory {
     @MainActor
     static func create(playaDB: PlayaDB) -> AISearchService? {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            let service = FoundationModelSearchService(playaDB: playaDB)
+            return service.isAvailable ? service : nil
+        }
+        #endif
+        return nil
+    }
+
+    @MainActor
+    static func createAssistant(playaDB: PlayaDB) -> AIAssistantService? {
         #if canImport(FoundationModels)
         if #available(iOS 26, *) {
             let service = FoundationModelSearchService(playaDB: playaDB)

--- a/iBurn/AISearch/AISearchService.swift
+++ b/iBurn/AISearch/AISearchService.swift
@@ -1,0 +1,105 @@
+//
+//  AISearchService.swift
+//  iBurn
+//
+//  Created by Claude Code on 4/5/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+
+import Foundation
+@preconcurrency import PlayaDB
+
+/// Result from AI-powered semantic search
+struct AISearchResult: Sendable {
+    let uid: String
+    let reason: String
+}
+
+/// Protocol for AI-powered semantic search
+protocol AISearchService: Sendable {
+    /// Whether AI search is available on this device
+    var isAvailable: Bool { get }
+
+    /// Perform semantic search using on-device language model
+    func search(_ query: String) async throws -> [AISearchResult]
+}
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+/// AI search implementation using Apple Foundation Models (iOS 26+)
+@available(iOS 26, *)
+final class FoundationModelSearchService: AISearchService {
+    private let playaDB: PlayaDB
+
+    var isAvailable: Bool {
+        SystemLanguageModel.default.isAvailable
+    }
+
+    init(playaDB: PlayaDB) {
+        self.playaDB = playaDB
+    }
+
+    func search(_ query: String) async throws -> [AISearchResult] {
+        guard isAvailable else { return [] }
+
+        let tools: [any Tool] = [
+            SearchByKeywordTool(playaDB: playaDB),
+            FetchArtTool(playaDB: playaDB),
+            FetchCampsTool(playaDB: playaDB),
+            FetchMutantVehiclesTool(playaDB: playaDB),
+        ]
+
+        let session = LanguageModelSession(
+            tools: tools,
+            instructions: """
+                You are a search assistant for the Burning Man festival guide app. \
+                Use the provided tools to find art installations, theme camps, events, \
+                and mutant vehicles matching the user's query. Return the most relevant \
+                results as a JSON array of objects with "uid" and "reason" fields. \
+                Keep reasons brief (under 10 words).
+                """
+        )
+
+        let response = try await session.respond(
+            to: Prompt(query),
+            generating: AISearchResponse.self
+        )
+
+        return response.content.results.map {
+            AISearchResult(uid: $0.uid, reason: $0.reason)
+        }
+    }
+}
+
+@available(iOS 26, *)
+@Generable
+struct AISearchResultItem {
+    @Guide(description: "Object uid")
+    var uid: String
+    @Guide(description: "Brief reason this matches")
+    var reason: String
+}
+
+@available(iOS 26, *)
+@Generable
+struct AISearchResponse {
+    @Guide(description: "Matching results", .count(1...10))
+    var results: [AISearchResultItem]
+}
+
+#endif
+
+/// Factory for creating the appropriate AI search service
+enum AISearchServiceFactory {
+    @MainActor
+    static func create(playaDB: PlayaDB) -> AISearchService? {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            let service = FoundationModelSearchService(playaDB: playaDB)
+            return service.isAvailable ? service : nil
+        }
+        #endif
+        return nil
+    }
+}

--- a/iBurn/AISearch/PlayaSearchTools.swift
+++ b/iBurn/AISearch/PlayaSearchTools.swift
@@ -8,6 +8,8 @@
 
 #if canImport(FoundationModels)
 import Foundation
+import CoreLocation
+import MapKit
 import FoundationModels
 @preconcurrency import PlayaDB
 
@@ -112,6 +114,95 @@ struct FetchMutantVehiclesTool: Tool {
         return results.prefix(10).map { mv in
             let desc = mv.description?.prefix(80) ?? "no description"
             return "vehicle: \(mv.name) - \(desc) (uid: \(mv.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - Get Favorites (taste profile)
+
+@available(iOS 26, *)
+struct GetFavoritesTool: Tool {
+    let name = "getFavorites"
+    let description = "Get the user's favorited art, camps, events, and vehicles"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Unused, pass empty string")
+        var placeholder: String?
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        let favorites = try await playaDB.getFavorites()
+        if favorites.isEmpty { return "No favorites yet." }
+        return favorites.prefix(20).map { obj in
+            "\(obj.objectType.rawValue): \(obj.name) (uid: \(obj.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - Fetch Upcoming Events
+
+@available(iOS 26, *)
+struct FetchUpcomingEventsTool: Tool {
+    let name = "fetchUpcomingEvents"
+    let description = "Find events starting within the next few hours"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Hours ahead to look", .range(1...12))
+        var withinHours: Int
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        let events = try await playaDB.fetchUpcomingEvents(
+            within: arguments.withinHours, from: Date()
+        )
+        if events.isEmpty { return "No upcoming events found." }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        formatter.timeZone = TimeZone(identifier: "America/Los_Angeles")
+        return events.prefix(15).map { occ in
+            let time = formatter.string(from: occ.startDate)
+            let desc = occ.event.description?.prefix(60) ?? ""
+            return "event: \(occ.event.name) at \(time) - \(desc) (uid: \(occ.event.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - Fetch Nearby Objects
+
+@available(iOS 26, *)
+struct FetchNearbyObjectsTool: Tool {
+    let name = "fetchNearby"
+    let description = "Find art, camps, and events near a GPS location"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "GPS latitude")
+        var latitude: Double
+        @Guide(description: "GPS longitude")
+        var longitude: Double
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        let center = CLLocationCoordinate2D(
+            latitude: arguments.latitude,
+            longitude: arguments.longitude
+        )
+        let region = MKCoordinateRegion(
+            center: center,
+            span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
+        )
+        let objects = try await playaDB.fetchObjects(in: region)
+        if objects.isEmpty { return "Nothing found nearby." }
+        return objects.prefix(15).map { obj in
+            "\(obj.objectType.rawValue): \(obj.name) (uid: \(obj.uid))"
         }.joined(separator: "\n")
     }
 }

--- a/iBurn/AISearch/PlayaSearchTools.swift
+++ b/iBurn/AISearch/PlayaSearchTools.swift
@@ -1,0 +1,119 @@
+//
+//  PlayaSearchTools.swift
+//  iBurn
+//
+//  Created by Claude Code on 4/5/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+
+#if canImport(FoundationModels)
+import Foundation
+import FoundationModels
+@preconcurrency import PlayaDB
+
+// MARK: - Search by Keyword (FTS5)
+
+@available(iOS 26, *)
+struct SearchByKeywordTool: Tool {
+    let name = "searchByKeyword"
+    let description = "Full-text search across all art, camps, events, and vehicles"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Search keywords")
+        var query: String
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        let results = try await playaDB.searchObjects(arguments.query)
+        if results.isEmpty { return "No results found." }
+        return results.prefix(15).map { obj in
+            "\(obj.objectType.rawValue): \(obj.name) (uid: \(obj.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - Fetch Art
+
+@available(iOS 26, *)
+struct FetchArtTool: Tool {
+    let name = "fetchArt"
+    let description = "Search art installations by keyword"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Keyword to search for")
+        var keyword: String?
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        var filter = ArtFilter.all
+        filter.searchText = arguments.keyword
+        let results = try await playaDB.fetchArt(filter: filter)
+        if results.isEmpty { return "No art found." }
+        return results.prefix(10).map { art in
+            let desc = art.description?.prefix(80) ?? "no description"
+            return "art: \(art.name) - \(desc) (uid: \(art.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - Fetch Camps
+
+@available(iOS 26, *)
+struct FetchCampsTool: Tool {
+    let name = "fetchCamps"
+    let description = "Search theme camps by keyword"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Keyword to search for")
+        var keyword: String?
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        var filter = CampFilter.all
+        filter.searchText = arguments.keyword
+        let results = try await playaDB.fetchCamps(filter: filter)
+        if results.isEmpty { return "No camps found." }
+        return results.prefix(10).map { camp in
+            let desc = camp.description?.prefix(80) ?? "no description"
+            return "camp: \(camp.name) - \(desc) (uid: \(camp.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - Fetch Mutant Vehicles
+
+@available(iOS 26, *)
+struct FetchMutantVehiclesTool: Tool {
+    let name = "fetchVehicles"
+    let description = "Search mutant vehicles by keyword or tags"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Keyword to search for")
+        var keyword: String?
+    }
+
+    let playaDB: PlayaDB
+
+    func call(arguments: Arguments) async throws -> String {
+        var filter = MutantVehicleFilter.all
+        filter.searchText = arguments.keyword
+        let results = try await playaDB.fetchMutantVehicles(filter: filter)
+        if results.isEmpty { return "No vehicles found." }
+        return results.prefix(10).map { mv in
+            let desc = mv.description?.prefix(80) ?? "no description"
+            return "vehicle: \(mv.name) - \(desc) (uid: \(mv.uid))"
+        }.joined(separator: "\n")
+    }
+}
+
+#endif

--- a/iBurn/DependencyContainer.swift
+++ b/iBurn/DependencyContainer.swift
@@ -61,6 +61,11 @@ class DependencyContainer {
         AISearchServiceFactory.create(playaDB: playaDB)
     }()
 
+    /// AI assistant service for recommendations, day planner, nearby (nil if unavailable)
+    private(set) lazy var aiAssistantService: AIAssistantService? = {
+        AISearchServiceFactory.createAssistant(playaDB: playaDB)
+    }()
+
     // MARK: - Initialization
 
     /// Initialize the dependency container
@@ -164,6 +169,16 @@ class DependencyContainer {
             isDatabaseSeeded: { [mutantVehicleDataProvider] in
                 await mutantVehicleDataProvider.isDatabaseSeeded()
             }
+        )
+    }
+
+    /// Create an AIAssistantViewModel (nil if AI not available)
+    func makeAIAssistantViewModel() -> AIAssistantViewModel? {
+        guard let aiService = aiAssistantService else { return nil }
+        return AIAssistantViewModel(
+            aiService: aiService,
+            playaDB: playaDB,
+            locationProvider: locationProvider
         )
     }
 

--- a/iBurn/DependencyContainer.swift
+++ b/iBurn/DependencyContainer.swift
@@ -56,6 +56,11 @@ class DependencyContainer {
         MutantVehicleDataProvider(playaDB: playaDB)
     }()
 
+    /// AI search service (nil if device doesn't support Apple Intelligence)
+    private(set) lazy var aiSearchService: AISearchService? = {
+        AISearchServiceFactory.create(playaDB: playaDB)
+    }()
+
     // MARK: - Initialization
 
     /// Initialize the dependency container
@@ -88,7 +93,7 @@ class DependencyContainer {
 
     /// Create a GlobalSearchViewModel with injected dependencies
     func makeGlobalSearchViewModel() -> GlobalSearchViewModel {
-        GlobalSearchViewModel(playaDB: playaDB)
+        GlobalSearchViewModel(playaDB: playaDB, aiSearchService: aiSearchService)
     }
 
     /// Create a GlobalSearchHostingController for use as UISearchController.searchResultsController

--- a/iBurn/ListView/GlobalSearchView.swift
+++ b/iBurn/ListView/GlobalSearchView.swift
@@ -72,6 +72,18 @@ struct GlobalSearchView: View {
                             }
                         }
                     }
+                    if viewModel.isAISearching {
+                        Section {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                Text("Finding more with AI...")
+                                    .font(.caption)
+                                    .foregroundColor(themeColors.secondaryColor)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .listRowBackground(Color.clear)
+                        }
+                    }
                 }
                 .listStyle(.plain)
             }
@@ -82,6 +94,7 @@ struct GlobalSearchView: View {
 
     @ViewBuilder
     private func resultRow(for item: SearchResultItem) -> some View {
+        let isAISuggested = viewModel.aiSuggestedUIDs.contains(item.uid)
         switch item {
         case .art(let art):
             MediaObjectRowView(
@@ -91,6 +104,7 @@ struct GlobalSearchView: View {
                 isFavorite: false,
                 onFavoriteTap: { }
             ) { _ in EmptyView() }
+            .overlay(alignment: .topTrailing) { aiBadge(visible: isAISuggested) }
             .contentShape(Rectangle())
             .onTapGesture { onSelectArt(art) }
 
@@ -102,11 +116,13 @@ struct GlobalSearchView: View {
                 isFavorite: false,
                 onFavoriteTap: { }
             ) { _ in EmptyView() }
+            .overlay(alignment: .topTrailing) { aiBadge(visible: isAISuggested) }
             .contentShape(Rectangle())
             .onTapGesture { onSelectCamp(camp) }
 
         case .event(let event):
             eventResultRow(for: event)
+                .overlay(alignment: .topTrailing) { aiBadge(visible: isAISuggested) }
 
         case .mutantVehicle(let mv):
             MediaObjectRowView(
@@ -116,8 +132,19 @@ struct GlobalSearchView: View {
                 isFavorite: false,
                 onFavoriteTap: { }
             ) { _ in EmptyView() }
+            .overlay(alignment: .topTrailing) { aiBadge(visible: isAISuggested) }
             .contentShape(Rectangle())
             .onTapGesture { onSelectMV(mv) }
+        }
+    }
+
+    @ViewBuilder
+    private func aiBadge(visible: Bool) -> some View {
+        if visible {
+            Image(systemName: "sparkles")
+                .font(.caption2)
+                .foregroundStyle(.purple)
+                .padding(2)
         }
     }
 

--- a/iBurn/ListView/GlobalSearchViewModel.swift
+++ b/iBurn/ListView/GlobalSearchViewModel.swift
@@ -12,38 +12,57 @@ final class GlobalSearchViewModel: ObservableObject {
     @Published var sections: [SearchResultSection] = []
     @Published var isSearching: Bool = false
 
+    /// UIDs of results that came from AI semantic search (not FTS5)
+    @Published var aiSuggestedUIDs: Set<String> = []
+
+    /// Whether AI search is currently running (FTS5 results already shown)
+    @Published var isAISearching: Bool = false
+
     // MARK: - Dependencies
 
     private let playaDB: PlayaDB
+    private let aiSearchService: AISearchService?
 
     // MARK: - Tasks
 
     private var searchTask: Task<Void, Never>?
+    private var aiSearchTask: Task<Void, Never>?
 
     // MARK: - Init
 
-    init(playaDB: PlayaDB) {
+    init(playaDB: PlayaDB, aiSearchService: AISearchService? = nil) {
         self.playaDB = playaDB
+        self.aiSearchService = aiSearchService
     }
 
     deinit {
         searchTask?.cancel()
+        aiSearchTask?.cancel()
+    }
+
+    /// Whether AI-enhanced search is available on this device
+    var isAISearchAvailable: Bool {
+        aiSearchService?.isAvailable == true
     }
 
     // MARK: - Search
 
     private func scheduleSearch() {
         searchTask?.cancel()
+        aiSearchTask?.cancel()
 
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard query.count >= 2 else {
             sections = []
+            aiSuggestedUIDs = []
             isSearching = false
+            isAISearching = false
             return
         }
 
         isSearching = true
+        aiSuggestedUIDs = []
 
         searchTask = Task { [weak self] in
             // Debounce 0.3 seconds
@@ -56,9 +75,16 @@ final class GlobalSearchViewModel: ObservableObject {
                 let results = try await self.playaDB.searchObjects(query)
                 guard !Task.isCancelled else { return }
 
+                let ftsUIDs = Set(results.map { $0.uid })
+
                 await MainActor.run {
                     self.sections = Self.groupResults(results)
                     self.isSearching = false
+                }
+
+                // Launch AI search in parallel if available
+                if let aiService = self.aiSearchService, aiService.isAvailable {
+                    await self.runAISearch(query: query, ftsUIDs: ftsUIDs)
                 }
             } catch {
                 guard !Task.isCancelled else { return }
@@ -69,6 +95,81 @@ final class GlobalSearchViewModel: ObservableObject {
                 print("Search error: \(error)")
             }
         }
+    }
+
+    /// Run AI search and merge any new results not found by FTS5
+    private func runAISearch(query: String, ftsUIDs: Set<String>) async {
+        guard let aiService = aiSearchService else { return }
+        guard !Task.isCancelled else { return }
+
+        await MainActor.run { self.isAISearching = true }
+
+        do {
+            let aiResults = try await aiService.search(query)
+            guard !Task.isCancelled else { return }
+
+            // Find UIDs that AI found but FTS5 missed
+            let newUIDs = aiResults.map(\.uid).filter { !ftsUIDs.contains($0) }
+
+            if !newUIDs.isEmpty {
+                // Fetch the actual objects for these UIDs and build SearchResultItems
+                var newItems: [SearchResultItem] = []
+                for uid in newUIDs {
+                    if let art = try? await playaDB.fetchArt(uid: uid) {
+                        newItems.append(.art(art))
+                    } else if let camp = try? await playaDB.fetchCamp(uid: uid) {
+                        newItems.append(.camp(camp))
+                    } else if let event = try? await playaDB.fetchEvent(uid: uid) {
+                        newItems.append(.event(event))
+                    } else if let mv = try? await playaDB.fetchMutantVehicle(uid: uid) {
+                        newItems.append(.mutantVehicle(mv))
+                    }
+                }
+
+                await MainActor.run {
+                    self.aiSuggestedUIDs = Set(newUIDs)
+                    self.mergeAIResults(newItems)
+                    self.isAISearching = false
+                }
+            } else {
+                await MainActor.run { self.isAISearching = false }
+            }
+        } catch {
+            print("AI search error: \(error)")
+            await MainActor.run { self.isAISearching = false }
+        }
+    }
+
+    /// Merge AI-discovered items into existing sections
+    private func mergeAIResults(_ newItems: [SearchResultItem]) {
+        var artItems = sections.first(where: { $0.id == .art })?.items ?? []
+        var campItems = sections.first(where: { $0.id == .camp })?.items ?? []
+        var eventItems = sections.first(where: { $0.id == .event })?.items ?? []
+        var mvItems = sections.first(where: { $0.id == .mutantVehicle })?.items ?? []
+
+        for item in newItems {
+            switch item {
+            case .art: artItems.append(item)
+            case .camp: campItems.append(item)
+            case .event: eventItems.append(item)
+            case .mutantVehicle: mvItems.append(item)
+            }
+        }
+
+        var newSections: [SearchResultSection] = []
+        if !artItems.isEmpty {
+            newSections.append(SearchResultSection(id: .art, title: "Art", items: artItems))
+        }
+        if !campItems.isEmpty {
+            newSections.append(SearchResultSection(id: .camp, title: "Camps", items: campItems))
+        }
+        if !eventItems.isEmpty {
+            newSections.append(SearchResultSection(id: .event, title: "Events", items: eventItems))
+        }
+        if !mvItems.isEmpty {
+            newSections.append(SearchResultSection(id: .mutantVehicle, title: "Vehicles", items: mvItems))
+        }
+        self.sections = newSections
     }
 
     // MARK: - Grouping

--- a/iBurn/MoreViewController.swift
+++ b/iBurn/MoreViewController.swift
@@ -53,9 +53,10 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
         case art = 0
         case camps = 1
         case mutantVehicles = 2
-        case visitList = 3
-        case audioTour = 4
-        case locationHistory = 5
+        case aiAssistant = 3
+        case visitList = 4
+        case audioTour = 5
+        case locationHistory = 6
     }
     
     enum CustomizationRow: Int, CaseIterable {
@@ -85,13 +86,13 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
         case contact(ContactRow)
         case extras(ExtrasRow)
         
-        init?(indexPath: IndexPath) {
+        init?(indexPath: IndexPath, visibleDetailRows: [DetailViewsRow]) {
             guard let section = Section(rawValue: indexPath.section) else { return nil }
-            
+
             switch section {
             case .detailViews:
-                guard let row = DetailViewsRow(rawValue: indexPath.row) else { return nil }
-                self = .detailViews(row)
+                guard indexPath.row < visibleDetailRows.count else { return nil }
+                self = .detailViews(visibleDetailRows[indexPath.row])
             case .customization:
                 guard let row = CustomizationRow(rawValue: indexPath.row) else { return nil }
                 self = .customization(row)
@@ -150,11 +151,20 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
         return Section.allCases.count
     }
     
+    private var visibleDetailViewRows: [DetailViewsRow] {
+        DetailViewsRow.allCases.filter { row in
+            if row == .aiAssistant {
+                return BRCAppDelegate.shared.dependencies.aiAssistantService != nil
+            }
+            return true
+        }
+    }
+
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard let section = Section(rawValue: section) else { return 0 }
-        
+
         switch section {
-        case .detailViews: return DetailViewsRow.allCases.count
+        case .detailViews: return visibleDetailViewRows.count
         case .customization: return CustomizationRow.allCases.count
         case .contact: return ContactRow.allCases.count
         case .extras: return ExtrasRow.allCases.count
@@ -168,7 +178,7 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
     
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cellType = CellType(indexPath: indexPath) else {
+        guard let cellType = CellType(indexPath: indexPath, visibleDetailRows: visibleDetailViewRows) else {
             fatalError("Invalid index path")
         }
         
@@ -184,6 +194,8 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
                 moreCell.configure(title: "Camps", imageName: "BRCCampIcon", tag: row.rawValue)
             case .mutantVehicles:
                 moreCell.configure(title: "Mutant Vehicles", systemImageName: "car.fill", tag: row.rawValue)
+            case .aiAssistant:
+                moreCell.configure(title: "AI Assistant", systemImageName: "sparkles", tag: row.rawValue)
             case .visitList:
                 moreCell.configure(title: "Visit List", systemImageName: "bookmark.circle", tag: row.rawValue)
             case .audioTour:
@@ -262,7 +274,7 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard let cellType = CellType(indexPath: indexPath) else { return }
+        guard let cellType = CellType(indexPath: indexPath, visibleDetailRows: visibleDetailViewRows) else { return }
         
         let cell = tableView.cellForRow(at: indexPath)
         
@@ -272,6 +284,7 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
             case .art: pushArtView()
             case .camps: pushCampsView()
             case .mutantVehicles: pushMutantVehiclesView()
+            case .aiAssistant: pushAIAssistantView()
             case .visitList: pushVisitListView()
             case .audioTour: showAudioTour()
             case .locationHistory: pushTracksView()
@@ -363,6 +376,15 @@ class MoreViewController: UITableViewController, SKStoreProductViewControllerDel
         navigationController?.pushViewController(campsVC, animated: true)
     }
     
+    func pushAIAssistantView() {
+        guard let vm = BRCAppDelegate.shared.dependencies.makeAIAssistantViewModel() else { return }
+        let view = AIAssistantView(viewModel: vm)
+        let hostingVC = UIHostingController(rootView: view)
+        hostingVC.title = "AI Assistant"
+        hostingVC.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(hostingVC, animated: true)
+    }
+
     func pushMutantVehiclesView() {
         let mvVC = MutantVehicleListHostingController(dependencies: BRCAppDelegate.shared.dependencies)
         mvVC.title = "Mutant Vehicles"

--- a/iBurnTests/AISearchToolTests.swift
+++ b/iBurnTests/AISearchToolTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import CoreLocation
 @preconcurrency @testable import iBurn
 @testable import PlayaDB
 
@@ -181,6 +182,93 @@ final class AISearchToolTests: XCTestCase {
         // Combined output should fit in context window (~4096 tokens ≈ ~16000 chars)
         let totalLength = keywordResult.count + artResult.count + campResult.count + mvResult.count
         XCTAssertLessThan(totalLength, 16000, "Combined tool output should fit in context window")
+    }
+
+    // MARK: - GetFavoritesTool Tests
+
+    func testGetFavoritesTool_NoFavorites() async throws {
+        let tool = GetFavoritesTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(placeholder: nil))
+        XCTAssertEqual(result, "No favorites yet.")
+    }
+
+    func testGetFavoritesTool_WithFavorites() async throws {
+        // Favorite an art piece
+        let art = try await playaDB.fetchArt()
+        XCTAssertFalse(art.isEmpty)
+        try await playaDB.toggleFavorite(art[0])
+
+        let tool = GetFavoritesTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(placeholder: nil))
+
+        XCTAssertTrue(result.contains("Burning Questions"), "Should list favorited art")
+        XCTAssertTrue(result.contains("uid:"), "Should include uid")
+    }
+
+    // MARK: - FetchUpcomingEventsTool Tests
+
+    func testFetchUpcomingEventsTool() async throws {
+        let tool = FetchUpcomingEventsTool(playaDB: playaDB)
+        // Events in fixture are in 2025, so "upcoming" from now returns nothing
+        let result = try await tool.call(arguments: .init(withinHours: 12))
+        // Either finds events or returns empty message
+        XCTAssertFalse(result.isEmpty, "Should return some output")
+    }
+
+    // MARK: - FetchNearbyObjectsTool Tests
+
+    func testFetchNearbyObjectsTool_AtBRC() async throws {
+        let tool = FetchNearbyObjectsTool(playaDB: playaDB)
+        // Art fixture has GPS at ~40.79, -119.19
+        let result = try await tool.call(arguments: .init(
+            latitude: 40.7918,
+            longitude: -119.1977
+        ))
+
+        XCTAssertTrue(result.contains("Burning Questions"),
+                      "Should find art near its GPS coordinates")
+    }
+
+    func testFetchNearbyObjectsTool_NowhereNearBRC() async throws {
+        let tool = FetchNearbyObjectsTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(
+            latitude: 0.0,
+            longitude: 0.0
+        ))
+        XCTAssertEqual(result, "Nothing found nearby.")
+    }
+
+    // MARK: - AIAssistantService Tests
+
+    func testAssistantService_AvailabilityCheck() {
+        let service = FoundationModelSearchService(playaDB: playaDB)
+        // Just verify it doesn't crash
+        _ = service.isAvailable
+    }
+
+    func testAssistantService_RecommendWhenUnavailable() async throws {
+        let service = FoundationModelSearchService(playaDB: playaDB)
+        if !service.isAvailable {
+            let results = try await service.recommend()
+            XCTAssertTrue(results.isEmpty, "Should return empty when AI unavailable")
+        }
+    }
+
+    func testAssistantService_WhatsNearbyWhenUnavailable() async throws {
+        let service = FoundationModelSearchService(playaDB: playaDB)
+        if !service.isAvailable {
+            let loc = CLLocation(latitude: 40.7864, longitude: -119.2065)
+            let results = try await service.whatsNearby(location: loc)
+            XCTAssertTrue(results.isEmpty, "Should return empty when AI unavailable")
+        }
+    }
+
+    func testAssistantService_PlanDayWhenUnavailable() async throws {
+        let service = FoundationModelSearchService(playaDB: playaDB)
+        if !service.isAvailable {
+            let plan = try await service.planDay(date: Date(), location: nil)
+            XCTAssertTrue(plan.schedule.isEmpty, "Should return empty when AI unavailable")
+        }
     }
 
     // MARK: - Fixture Data

--- a/iBurnTests/AISearchToolTests.swift
+++ b/iBurnTests/AISearchToolTests.swift
@@ -1,0 +1,205 @@
+//
+//  AISearchToolTests.swift
+//  iBurnTests
+//
+//  Created by Claude Code on 4/5/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+
+import XCTest
+@preconcurrency @testable import iBurn
+@testable import PlayaDB
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+@available(iOS 26, *)
+@MainActor
+final class AISearchToolTests: XCTestCase {
+
+    private var playaDB: PlayaDB!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        playaDB = try PlayaDBImpl(dbPath: ":memory:")
+        try await playaDB.importFromData(
+            artData: Self.artJSON,
+            campData: Self.campJSON,
+            eventData: Self.eventJSON,
+            mvData: Self.mvJSON
+        )
+    }
+
+    override func tearDown() async throws {
+        playaDB = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - SearchByKeywordTool Tests
+
+    func testSearchByKeywordTool_FindsArt() async throws {
+        let tool = SearchByKeywordTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(query: "Burning"))
+
+        XCTAssertTrue(result.contains("Burning Questions"), "Should find art by name")
+        XCTAssertTrue(result.contains("a2IVI000000yWeZ2AU"), "Should include uid")
+    }
+
+    func testSearchByKeywordTool_FindsCamp() async throws {
+        let tool = SearchByKeywordTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(query: "ASL"))
+
+        XCTAssertTrue(result.contains("Camp ASL"), "Should find camp by name")
+        XCTAssertTrue(result.contains("a1XVI000008zSaf2AE"), "Should include uid")
+    }
+
+    func testSearchByKeywordTool_FindsMV() async throws {
+        let tool = SearchByKeywordTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(query: "Dragon"))
+
+        XCTAssertTrue(result.contains("Dragon Wagon"), "Should find MV by name")
+        XCTAssertTrue(result.contains("a6BVI000000Xf1r3BC"), "Should include uid")
+    }
+
+    func testSearchByKeywordTool_NoResults() async throws {
+        let tool = SearchByKeywordTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(query: "zzzznonexistent"))
+
+        XCTAssertEqual(result, "No results found.")
+    }
+
+    // MARK: - FetchArtTool Tests
+
+    func testFetchArtTool_AllArt() async throws {
+        let tool = FetchArtTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: nil))
+
+        XCTAssertTrue(result.contains("Burning Questions"), "Should return art")
+        XCTAssertTrue(result.contains("a2IVI000000yWeZ2AU"), "Should include uid")
+    }
+
+    func testFetchArtTool_WithKeyword() async throws {
+        let tool = FetchArtTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: "curiosity"))
+
+        // "curiosity" appears in description: "exploring curiosity and wonder"
+        XCTAssertTrue(result.contains("Burning Questions"),
+                      "Should find art with 'curiosity' in description")
+    }
+
+    func testFetchArtTool_NoMatch() async throws {
+        let tool = FetchArtTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: "zzzznotfound"))
+
+        XCTAssertEqual(result, "No art found.")
+    }
+
+    // MARK: - FetchCampsTool Tests
+
+    func testFetchCampsTool_AllCamps() async throws {
+        let tool = FetchCampsTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: nil))
+
+        XCTAssertTrue(result.contains("Camp ASL"), "Should return camps")
+    }
+
+    func testFetchCampsTool_WithKeyword() async throws {
+        let tool = FetchCampsTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: "sign language"))
+
+        XCTAssertTrue(result.contains("Camp ASL"),
+                      "Should find camp with 'sign language' in description")
+    }
+
+    // MARK: - FetchMutantVehiclesTool Tests
+
+    func testFetchMutantVehiclesTool_AllMVs() async throws {
+        let tool = FetchMutantVehiclesTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: nil))
+
+        XCTAssertTrue(result.contains("Dragon Wagon"), "Should return MVs")
+        XCTAssertTrue(result.contains("Moebius Omnibus"), "Should return all MVs")
+    }
+
+    func testFetchMutantVehiclesTool_WithKeyword() async throws {
+        let tool = FetchMutantVehiclesTool(playaDB: playaDB)
+        let result = try await tool.call(arguments: .init(keyword: "dragon"))
+
+        XCTAssertTrue(result.contains("Dragon Wagon"), "Should find MV by keyword")
+        XCTAssertFalse(result.contains("Moebius"), "Should not include non-matching MVs")
+    }
+
+    // MARK: - FoundationModelSearchService Tests
+
+    func testFoundationModelSearchService_AvailabilityCheck() {
+        let service = FoundationModelSearchService(playaDB: playaDB)
+        // Just verify the availability check doesn't crash
+        // On simulator, isAvailable will be false
+        _ = service.isAvailable
+    }
+
+    func testFoundationModelSearchService_SearchWhenUnavailable() async throws {
+        let service = FoundationModelSearchService(playaDB: playaDB)
+        // On simulator without Apple Intelligence, search should return empty
+        if !service.isAvailable {
+            let results = try await service.search("test query")
+            XCTAssertTrue(results.isEmpty, "Should return empty when AI unavailable")
+        }
+    }
+
+    // MARK: - AISearchServiceFactory Tests
+
+    func testAISearchServiceFactory_CreatesService() {
+        // Factory should create a service (may be nil if AI unavailable on simulator)
+        let service = AISearchServiceFactory.create(playaDB: playaDB)
+        if SystemLanguageModel.default.isAvailable {
+            XCTAssertNotNil(service, "Should create service when AI is available")
+        } else {
+            XCTAssertNil(service, "Should return nil when AI is unavailable")
+        }
+    }
+
+    // MARK: - End-to-End Tool Flow Tests
+
+    func testToolOutputIsWellFormatted() async throws {
+        // Verify all tool outputs follow a consistent format the model can parse
+        let keywordTool = SearchByKeywordTool(playaDB: playaDB)
+        let artTool = FetchArtTool(playaDB: playaDB)
+        let campTool = FetchCampsTool(playaDB: playaDB)
+        let mvTool = FetchMutantVehiclesTool(playaDB: playaDB)
+
+        let keywordResult = try await keywordTool.call(arguments: .init(query: "Burning"))
+        let artResult = try await artTool.call(arguments: .init(keyword: nil))
+        let campResult = try await campTool.call(arguments: .init(keyword: nil))
+        let mvResult = try await mvTool.call(arguments: .init(keyword: nil))
+
+        // All results should contain uid references
+        for result in [keywordResult, artResult, campResult, mvResult] {
+            XCTAssertTrue(result.contains("uid:"), "Tool output should contain uid references: \(result)")
+        }
+
+        // Combined output should fit in context window (~4096 tokens ≈ ~16000 chars)
+        let totalLength = keywordResult.count + artResult.count + campResult.count + mvResult.count
+        XCTAssertLessThan(totalLength, 16000, "Combined tool output should fit in context window")
+    }
+
+    // MARK: - Fixture Data
+
+    private static let artJSON = """
+    [{"uid":"a2IVI000000yWeZ2AU","name":"Burning Questions","year":2025,"url":"https://www.burningquestions.com/","contact_email":"artist@burningquestions.com","hometown":"San Francisco, CA","description":"An interactive art installation exploring curiosity and wonder.","artist":"Jane Smith","category":"Open Playa","program":"Honorarium","donation_link":"https://crowdfundr.com/burningquestions","location":{"hour":12,"minute":0,"distance":2500,"category":"Open Playa","gps_latitude":40.79179890754886,"gps_longitude":-119.1976993927176},"location_string":"12:00 2500', Open Playa","images":[{"thumbnail_url":"https://example.com/art-image.jpeg","gallery_ref":"gallery-123"}],"guided_tours":false,"self_guided_tour_map":true}]
+    """.data(using: .utf8)!
+
+    private static let campJSON = """
+    [{"uid":"a1XVI000008zSaf2AE","name":"Camp ASL Support Services HUB","year":2025,"url":null,"contact_email":"ddhplanb@gmail.com","hometown":"All over, north, and, South America","description":"American sign language Support services. Centralized services for the Deaf.","landmark":"American sign language support services sign","location":{"frontage":"Esplanade","intersection":"6:30","intersection_type":"&","dimensions":"75 x 110","exact_location":"Mid-block facing 10:00"},"location_string":"Esplanade & 6:30","images":[]}]
+    """.data(using: .utf8)!
+
+    private static let eventJSON = """
+    [{"uid":"78ZvNxSeeZQbaeHuughD","title":"Fairycore Tarot Meetup","event_id":51138,"description":"First time picking up cards? A professional reader? All levels welcome","event_type":{"label":"Class/Workshop","abbr":"work"},"year":2025,"print_description":"","slug":"78ZvNxSeeZQbaeHuughD-fairycore-tarot-meetup","hosted_by_camp":"a1XVI000009t6XR2AY","located_at_art":null,"other_location":"","check_location":false,"url":null,"all_day":false,"contact":null,"occurrence_set":[{"start_time":"2025-08-28T12:00:00-07:00","end_time":"2025-08-28T13:30:00-07:00"}]}]
+    """.data(using: .utf8)!
+
+    private static let mvJSON = """
+    [{"uid":"a6BVI000000Xf1r3BC","name":"Dragon Wagon","year":2025,"description":"A fire-breathing dragon on wheels","artist":"Fire Arts Collective","hometown":"Portland, OR","url":"https://dragonwagon.com","contact_email":"info@dragonwagon.com","donation_link":null,"images":[{"thumbnail_url":"https://example.com/dragon.jpg"}],"tags":["Fire","Dragon"]},{"uid":"a6BVI000000Le0r2AC","name":"Moebius Omnibus","year":2025,"description":"A never-ending bus ride through infinity","artist":"Math Art Lab","hometown":"Austin, TX","url":null,"contact_email":null,"donation_link":null,"images":[],"tags":["Circular","Math"]}]
+    """.data(using: .utf8)!
+}
+
+#endif

--- a/iBurnTests/GlobalSearchViewModelTests.swift
+++ b/iBurnTests/GlobalSearchViewModelTests.swift
@@ -118,4 +118,69 @@ final class GlobalSearchViewModelTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - AI Search Integration Tests
+
+    func testInitialStateHasNoAISuggestions() {
+        XCTAssertTrue(viewModel.aiSuggestedUIDs.isEmpty)
+        XCTAssertFalse(viewModel.isAISearching)
+    }
+
+    func testAISearchNotAvailableWithoutService() {
+        // Default viewModel has no AI service
+        XCTAssertFalse(viewModel.isAISearchAvailable)
+    }
+
+    func testViewModelWithMockAIService() async {
+        let mockAI = MockAISearchService(results: [
+            AISearchResult(uid: "ai-uid-1", reason: "semantically relevant")
+        ])
+        let vm = GlobalSearchViewModel(playaDB: playaDB, aiSearchService: mockAI)
+
+        XCTAssertTrue(vm.isAISearchAvailable)
+
+        // Search should trigger FTS5 + AI
+        vm.searchText = "Burning"
+
+        // FTS5 results should appear
+        let hasResults = await eventually { !vm.sections.isEmpty }
+        XCTAssertTrue(hasResults, "Should have FTS5 results")
+
+        // AI search runs but the mock UID won't resolve to a real object,
+        // so aiSuggestedUIDs should be populated but no extra items merged
+        let aiDone = await eventually { !vm.isAISearching }
+        XCTAssertTrue(aiDone, "AI search should complete")
+    }
+
+    func testClearSearchClearsAISuggestions() async {
+        let mockAI = MockAISearchService(results: [
+            AISearchResult(uid: "ai-uid-1", reason: "test")
+        ])
+        let vm = GlobalSearchViewModel(playaDB: playaDB, aiSearchService: mockAI)
+
+        vm.searchText = "Burning"
+        let hasResults = await eventually { !vm.sections.isEmpty }
+        XCTAssertTrue(hasResults)
+
+        vm.searchText = ""
+        let cleared = await eventually { vm.aiSuggestedUIDs.isEmpty }
+        XCTAssertTrue(cleared, "Clearing search should clear AI suggestions")
+    }
+}
+
+// MARK: - Mock AI Search Service
+
+private final class MockAISearchService: AISearchService, @unchecked Sendable {
+    let results: [AISearchResult]
+    var isAvailable: Bool = true
+
+    init(results: [AISearchResult]) {
+        self.results = results
+    }
+
+    func search(_ query: String) async throws -> [AISearchResult] {
+        // Small delay to simulate model inference
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        return results
+    }
 }


### PR DESCRIPTION
## Summary
- Expose PlayaDB operations as Apple Foundation Models `Tool` protocol conformances (iOS 26+)
- On-device LLM decomposes natural language queries into structured DB operations
- **Semantic search**: FTS5 results appear instantly; AI results augment with sparkle badge
- **AI Assistant** with three features accessible from More screen:
  - **For You**: recommendations based on favorited items (taste profile)
  - **Day Planner**: time-ordered schedule from interests + location
  - **What's Nearby**: curated art/camps/events near current GPS
- 7 tools total: SearchByKeyword, FetchArt, FetchCamps, FetchMutantVehicles, GetFavorites, FetchUpcomingEvents, FetchNearby
- Graceful fallback: `#if canImport(FoundationModels)` + `@available(iOS 26, *)` -- AI row hidden on non-capable devices

## Test plan
- [x] Build: 0 errors, pre-existing warnings only
- [x] All iBurnTests pass (AI tool tests + ViewModel mock tests)
- [x] All PlayaDB tests pass (98 tests including AI search scenario tests)
- [ ] Test on physical device with Apple Intelligence enabled
- [ ] Verify AI Assistant row appears/hides based on device capability
- [ ] Verify recommendations reflect favorited items
- [ ] Verify day planner generates time-ordered schedule
- [ ] Verify nearby uses current GPS location

🤖 Generated with [Claude Code](https://claude.com/claude-code)