### PR TITLE
iOS 26 Liquid Glass navigation bar support

### DIFF
--- a/iBurn/Appearance.swift
+++ b/iBurn/Appearance.swift
@@ -190,6 +190,11 @@ extension Appearance {
     }
     
     @objc public static func applyNavigationBarAppearance(_ navBar: UINavigationBar, colors: BRCImageColors, animated: Bool) {
+        if #available(iOS 26, *) {
+            // iOS 26: let system Liquid Glass handle nav bar appearance
+            navBar.tintColor = colors.primaryColor
+            return
+        }
         let appearance = makeNavigationBarAppearance(colors: colors)
         let applyTheme = {
             navBar.standardAppearance = appearance

--- a/iBurn/Detail/Controllers/DetailHostingController.swift
+++ b/iBurn/Detail/Controllers/DetailHostingController.swift
@@ -73,11 +73,13 @@ class DetailHostingController: UIHostingController<DetailView>, DynamicViewContr
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Configure navigation bar appearance
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         setupNavigationBarAppearance()
     }
-    
+
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
@@ -107,7 +109,9 @@ class DetailHostingController: UIHostingController<DetailView>, DynamicViewContr
     }
     
     private func setupNavigationBarAppearance() {
-        // This can be customized based on existing app theming
-        // For now, use default appearance
+        if #available(iOS 26, *) {
+            // Transparent nav bar for Liquid Glass effect
+            navigationController?.navigationBar.isTranslucent = true
+        }
     }
 }

--- a/iBurn/Detail/Views/DetailView.swift
+++ b/iBurn/Detail/Views/DetailView.swift
@@ -55,6 +55,7 @@ struct DetailView: View {
         .background(backgroundColor)
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(viewModel.title)
+        .modifier(TransparentNavBarModifier())
         .sheet(isPresented: imageViewerBinding) {
             if let selected = viewModel.selectedImage {
                 ImageViewerSheet(image: selected)
@@ -782,6 +783,17 @@ struct DetailVisitStatusCell: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(PlainButtonStyle())
+        }
+    }
+}
+
+/// Hides the navigation bar background on iOS 26+ for Liquid Glass transparency.
+private struct TransparentNavBarModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content.toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+        } else {
+            content
         }
     }
 }

--- a/iBurn/PageViewManager.swift
+++ b/iBurn/PageViewManager.swift
@@ -45,7 +45,11 @@ import EventKitUI
         
         pageVC.delegate = self
         pageVC.dataSource = self
-        navBar?.isTranslucent = false
+        if #available(iOS 26, *) {
+            // Let iOS 26 Liquid Glass handle nav bar transparency
+        } else {
+            navBar?.isTranslucent = false
+        }
         navBar?.setColorTheme(colors, animated: false)
         pageVC.setViewControllers([detailVC], direction: .forward, animated: false, completion: nil)
         // Navigation item forwarding is now handled automatically by DetailPageViewController


### PR DESCRIPTION
## Summary
- Adapt navigation bars and detail views for iOS 26 Liquid Glass translucent chrome
- On iOS 26+, nav bars use system transparency instead of custom opaque appearance theming
- Older iOS versions are unaffected (all changes gated behind `@available(iOS 26, *)`)

## Changes
- **Appearance.swift** — Skip custom nav bar background styling on iOS 26, keep tint color only
- **DetailHostingController** — Move nav bar setup to `viewWillAppear`, enable translucency on iOS 26
- **DetailView** — Hide nav bar background via `toolbarBackgroundVisibility` for glass effect
- **PageViewManager** — Preserve translucency on iOS 26 instead of forcing opaque

## Test plan
- [ ] iOS 26 simulator/device: detail view nav bar shows Liquid Glass translucency
- [ ] iOS 18 simulator: nav bar appearance unchanged (opaque with theme colors)
- [ ] Swipe between detail pages — nav bar stays consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)