### PR TITLE
Add nearby card overlay to the main map

### DIFF
--- a/Docs/2026-05-30-nearby-card-on-map.md
+++ b/Docs/2026-05-30-nearby-card-on-map.md
@@ -1,0 +1,90 @@
+# 2026-05-30 — Nearby Card on the Main Map
+
+## High-Level Plan
+
+### Problem / Need
+The main map (`MainMapViewController`) shows pins but has no glanceable "what is right
+here next to me" affordance. We want a compact, swipeable card pinned near the bottom of
+the map that appears when the user is physically near art/camps/events, opens detail on tap,
+favorites items, plays audio tours where present, and minimizes into a badged FAB with a
+Liquid Glass morph.
+
+### Solution Overview
+A SwiftUI card hosted as a **proper child view controller** of the UIKit map (added via
+`addChild`/`didMove(toParent:)`, not by extracting the inner `UIView`). It reuses the app's
+existing data layer (data providers, `NearbyItem`, `RowAssetsLoader`, `AudioTourButton`,
+`DetailViewControllerFactory`, `CoreLocationProvider`) — only the UI is new.
+
+### Decisions (from user)
+- **Proximity radius**: ~100 m (tight, "what's right here").
+- **Types**: any object with GPS → art, camps, events. Mutant vehicles excluded (no GPS).
+- **Card content**: image, title, one-line description, event timing, audio play button
+  (audio-tour art only), and a favorite heart. Minimal.
+- **Deployment target is iOS 16.6** → iOS 26 Liquid Glass APIs gated behind
+  `#if canImport(FoundationModels)` + `if #available(iOS 26.0, *)`, with a
+  `.ultraThinMaterial` + `matchedGeometryEffect` fallback (mirrors the codebase's existing
+  iOS-26 gating pattern in `DependencyContainer.makeAIGuideViewModel`).
+
+### Prerequisite (done)
+Rebased the worktree branch `claude/fervent-knuth-adf76a` onto `ai-event-summary`
+(fast-forward to `a455b2e` — "PlayaDB: index event region queries with a spatio-temporal
+R*Tree"). This makes `EventFilter(region:)` queries R*Tree-backed (fast + correct: events
+hosted by in-region camps now return). No public API change; the card just builds on it.
+
+This card is **separate** from the planned "merge Nearby + Right Now" work
+(`~/.claude/plans/what-were-we-up-zippy-dongarra.md`, Phase B). It reuses the same providers
+and `NearbyItem` so the two stay consistent.
+
+## Technical Details
+
+### Files created (under `iBurn/Map/NearbyCard/` — Xcode 16 synchronized group, auto-included)
+- `NearbyCardViewModel.swift` — `@MainActor ObservableObject`. Observes
+  `Art/Camp/EventDataProvider.observeObjects(filter:)` over a ~100 m region + consumes
+  `CoreLocationProvider.locationStream`. Emits a flat, ordered `[NearbyItem]`:
+  - Events first (happening now / starting soon at `now`, by start time), then art + camps
+    merged by distance; gated to `nearbyRadius` (100 m), de-duped by id, capped to 12.
+  - Ordering extracted into pure `static func orderedItems(...)` for unit testing.
+  - `selectedID` tracked by `NearbyItem.id` (not index) and preserved across rebuilds so
+    location ticks don't yank the user mid-swipe; `isMinimized`; `now` refresh timer (30 s).
+  - Region recenters only after the user moves ≥ 25 m; small moves just re-sort/re-gate.
+- `NearbyCardView.swift` — paged card (`TabView` `.page` style, custom dots), compact
+  `NearbyCardContentView` (thumbnail via `RowAssetsLoader`, 1-line title/description, event
+  timing via `EventObjectOccurrence.timeDescription(now:)`, heart, `AudioTourButton` when
+  `assets.audioURL != nil`), minimize button, badged FAB. `GlassSurface` modifier applies
+  `.glassEffect(.regular.interactive(), …)` + shared `.glassEffectID("nearbyCard", …)` in a
+  `GlassEffectContainer` on iOS 26 (morph between card and FAB), else material + matched
+  geometry. Stable `cardWidth = min(380, screen − 32)`.
+- `NearbyCardHostingController.swift` — `UIHostingController<NearbyCardView>`, owns the VM,
+  `view.backgroundColor = .clear` + `sizingOptions = [.intrinsicContentSize]` (hosting view
+  hugs the card/FAB, so the rest of the map stays interactive), pushes
+  `DetailViewControllerFactory.create(with: subject, playaDB:)` on tap.
+
+### Files modified
+- `iBurn/DependencyContainer.swift` — added `makeNearbyCardViewModel()`.
+- `iBurn/MainMapViewController.swift` — store `dependencies`, add `setupNearbyCard()` which
+  `addChild`s the hosting controller bottom-centered (`autoAlignAxis(.vertical)` +
+  `autoPinEdge(toSuperviewMargin: .bottom)` −12) and calls `didMove(toParent:)`.
+
+### Tests
+- `iBurnTests/NearbyCardViewModelTests.swift` — 7 tests against `orderedItems(...)`:
+  events-first (even when farther), radius exclusion, art/camp distance sort, ended-event
+  exclusion, dedup by id, cap to maxItems, drop no-GPS objects. Uses real PlayaDB model
+  inits (no DB), `@MainActor`, no force-unwraps.
+
+## Outcomes / Verification
+- `xcodebuild build` (iBurn, iPhone 17 Pro Max, OS 26.2): **0 errors, 0 warnings** — the
+  Liquid Glass path compiles against the iOS 26.2 SDK.
+- `xcodebuild test -only-testing:iBurnTests/NearbyCardViewModelTests`: **7 passed, 0 failed**.
+- Note: SPM resolution requires network, so builds were run with the command sandbox
+  disabled.
+
+### Not yet done
+- On-device/simulator visual confirmation of the card + glass morph. Location data is
+  **embargoed until gates open** (current date 2026-05-30), so art/camp coordinates are
+  withheld and a quick simulator run likely surfaces no nearby objects. Visual verification
+  needs un-embargoed/dev data + a simulated GPS fix inside Black Rock City.
+
+### Possible follow-ups
+- Pause the VM's location polling / refresh timer when the map tab isn't visible (battery).
+- Minor: on narrow screens the centered card can slightly overlap the (currently
+  non-functional) bottom-left `SidebarButtonsView`.

--- a/iBurn/DependencyContainer.swift
+++ b/iBurn/DependencyContainer.swift
@@ -198,6 +198,17 @@ class DependencyContainer {
         )
     }
 
+    /// Create a NearbyCardViewModel for the on-map nearby card overlay
+    func makeNearbyCardViewModel() -> NearbyCardViewModel {
+        NearbyCardViewModel(
+            playaDB: playaDB,
+            artProvider: artDataProvider,
+            campProvider: campDataProvider,
+            eventProvider: eventDataProvider,
+            locationProvider: locationProvider
+        )
+    }
+
     /// Create a FavoritesViewModel with injected dependencies
     func makeFavoritesViewModel() -> FavoritesViewModel {
         FavoritesViewModel(

--- a/iBurn/MainMapViewController.swift
+++ b/iBurn/MainMapViewController.swift
@@ -26,6 +26,9 @@ public class MainMapViewController: BaseMapViewController, ListButtonHelper {
     private let globalSearchController: UISearchController
     private let globalSearchHostingController: GlobalSearchHostingController
     private let filteredDataSource: FilteredMapDataSource
+    private let dependencies: DependencyContainer
+    /// Compact on-map card showing art/camps/events within ~100m of the user.
+    private lazy var nearbyCardController = NearbyCardHostingController(dependencies: dependencies)
     var userMapViewAdapter: UserMapViewAdapter? {
         return mapViewAdapter as? UserMapViewAdapter
     }
@@ -42,6 +45,7 @@ public class MainMapViewController: BaseMapViewController, ListButtonHelper {
 
     public init() {
         let dependencies = BRCAppDelegate.shared.dependencies
+        self.dependencies = dependencies
         uiConnection = BRCDatabaseManager.shared.uiConnection
         writeConnection = BRCDatabaseManager.shared.readWriteConnection
         sidebarButtons = SidebarButtonsView()
@@ -116,8 +120,23 @@ public class MainMapViewController: BaseMapViewController, ListButtonHelper {
         setupSearchButton()
         setupListButton()
         setupFilterButton()
+        setupNearbyCard()
         definesPresentationContext = true
-        
+
+    }
+
+    /// Embeds the nearby card as a proper child view controller, bottom-centered. The
+    /// hosting controller uses intrinsic content sizing, so the card/FAB defines its own
+    /// frame and the rest of the map stays interactive around it.
+    private func setupNearbyCard() {
+        addChild(nearbyCardController)
+        let card = nearbyCardController.view!
+        view.addSubview(card)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.autoAlignAxis(toSuperviewAxis: .vertical)
+        let bottom = card.autoPinEdge(toSuperviewMargin: .bottom)
+        bottom.constant = -12
+        nearbyCardController.didMove(toParent: self)
     }
     
     private func setupSidebarButtons() {

--- a/iBurn/Map/NearbyCard/NearbyCardHostingController.swift
+++ b/iBurn/Map/NearbyCard/NearbyCardHostingController.swift
@@ -1,0 +1,54 @@
+//
+//  NearbyCardHostingController.swift
+//  iBurn
+//
+//  Created by Claude Code on 5/30/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+//  Hosts `NearbyCardView` so it can be embedded as a child view controller of the
+//  main map (added via addChild/didMove, not by extracting the inner UIView). Owns
+//  the view model and pushes detail views on tap through the map's navigation stack.
+//
+
+import SwiftUI
+import UIKit
+import PlayaDB
+
+@MainActor
+final class NearbyCardHostingController: UIHostingController<NearbyCardView> {
+    private let playaDB: PlayaDB
+    let viewModel: NearbyCardViewModel
+
+    init(dependencies: DependencyContainer) {
+        self.playaDB = dependencies.playaDB
+        let vm = dependencies.makeNearbyCardViewModel()
+        self.viewModel = vm
+        super.init(rootView: NearbyCardView(viewModel: vm))
+        self.rootView = NearbyCardView(
+            viewModel: vm,
+            onSelect: { [weak self] subject in
+                self?.showDetail(subject)
+            }
+        )
+        // The hosting view should only occupy (and intercept touches over) the card/FAB,
+        // leaving the rest of the map interactive. Clear background + intrinsic sizing.
+        view.backgroundColor = .clear
+        if #available(iOS 16.0, *) {
+            sizingOptions = [.intrinsicContentSize]
+        }
+    }
+
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+
+    private func showDetail(_ subject: DetailSubject) {
+        let detailVC = DetailViewControllerFactory.create(with: subject, playaDB: playaDB)
+        navigationController?.pushViewController(detailVC, animated: true)
+    }
+}

--- a/iBurn/Map/NearbyCard/NearbyCardView.swift
+++ b/iBurn/Map/NearbyCard/NearbyCardView.swift
@@ -1,0 +1,375 @@
+//
+//  NearbyCardView.swift
+//  iBurn
+//
+//  Created by Claude Code on 5/30/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+//  The on-map "nearby card": a compact, swipeable card pinned near the bottom of
+//  the main map showing what's within ~100m of the user. Events come first, then
+//  art + camps by distance. Tapping a card opens its detail view; a minimize
+//  button collapses the card into a badged FAB with a Liquid Glass morph (iOS 26),
+//  falling back to a material card + matched-geometry morph on earlier OSes.
+//
+
+import SwiftUI
+import PlayaDB
+
+struct NearbyCardView: View {
+    @ObservedObject var viewModel: NearbyCardViewModel
+    let onSelect: (DetailSubject) -> Void
+
+    private let audioPlayer: any AudioPlayerProtocol
+    @Namespace private var glassNS
+    @Environment(\.themeColors) private var themeColors
+
+    private let glassID = "nearbyCard"
+    private let cardCornerRadius: CGFloat = 22
+
+    /// A stable, device-appropriate card width. Fixed (not content-driven) so the card
+    /// doesn't jitter as you swipe between items with different text lengths, and capped
+    /// to the screen so it never overflows on small devices. Combined with the hosting
+    /// controller's intrinsic-content sizing, this keeps the touch area to just the card.
+    private var cardWidth: CGFloat {
+        min(380, UIScreen.main.bounds.width - 32)
+    }
+
+    init(
+        viewModel: NearbyCardViewModel,
+        onSelect: @escaping (DetailSubject) -> Void = { _ in },
+        audioPlayer: any AudioPlayerProtocol = BRCAudioPlayer.sharedInstance
+    ) {
+        self.viewModel = viewModel
+        self.onSelect = onSelect
+        self.audioPlayer = audioPlayer
+    }
+
+    var body: some View {
+        glassContainer {
+            Group {
+                if viewModel.items.isEmpty {
+                    // Collapses to zero intrinsic size so the host view doesn't block the map.
+                    Color.clear.frame(width: 0, height: 0)
+                } else if viewModel.isMinimized {
+                    fab
+                } else {
+                    card
+                }
+            }
+        }
+        .animation(.spring(response: 0.42, dampingFraction: 0.82), value: viewModel.isMinimized)
+        .animation(.easeInOut(duration: 0.25), value: viewModel.items.isEmpty)
+    }
+
+    // MARK: - Expanded card
+
+    private var card: some View {
+        VStack(spacing: 6) {
+            TabView(selection: $viewModel.selectedID) {
+                ForEach(viewModel.items) { item in
+                    NearbyCardContentView(
+                        item: item,
+                        now: viewModel.now,
+                        isFavorite: item.isFavorite,
+                        audioPlayer: audioPlayer,
+                        onFavoriteTap: { Task { await viewModel.toggleFavorite(item) } },
+                        onTap: { onSelect(item.detailSubject) }
+                    )
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .tag(item.id as String?)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(height: 84)
+
+            if viewModel.count > 1 {
+                pageDots
+                    .padding(.bottom, 8)
+            }
+        }
+        .frame(width: cardWidth)
+        .overlay(alignment: .topTrailing) { minimizeButton }
+        .modifier(GlassSurface(namespace: glassNS, glassID: glassID, shape: .roundedRect(cardCornerRadius)))
+    }
+
+    private var minimizeButton: some View {
+        Button {
+            viewModel.isMinimized = true
+        } label: {
+            Image(systemName: "chevron.down")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(themeColors.secondaryColor)
+                .frame(width: 30, height: 30)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(6)
+        .accessibilityLabel("Minimize nearby card")
+    }
+
+    private var pageDots: some View {
+        HStack(spacing: 6) {
+            ForEach(viewModel.items) { item in
+                Circle()
+                    .fill(item.id == viewModel.selectedID
+                          ? themeColors.primaryColor
+                          : themeColors.detailColor.opacity(0.35))
+                    .frame(width: 6, height: 6)
+            }
+        }
+    }
+
+    // MARK: - Minimized FAB
+
+    private var fab: some View {
+        Button {
+            viewModel.isMinimized = false
+        } label: {
+            Image(systemName: "mappin.and.ellipse")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(themeColors.primaryColor)
+                .frame(width: 56, height: 56)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .topTrailing) { countBadge }
+        .modifier(GlassSurface(namespace: glassNS, glassID: glassID, shape: .circle))
+        .accessibilityLabel("Show \(viewModel.count) nearby")
+    }
+
+    private var countBadge: some View {
+        Text("\(viewModel.count)")
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(.white)
+            .frame(minWidth: 18, minHeight: 18)
+            .padding(.horizontal, 3)
+            .background(Circle().fill(Color.red))
+            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 1.5))
+            .offset(x: 6, y: -4)
+    }
+
+    // MARK: - Glass container
+
+    @ViewBuilder
+    private func glassContainer<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer { content() }
+        } else {
+            content()
+        }
+        #else
+        content()
+        #endif
+    }
+}
+
+// MARK: - Glass surface modifier
+
+/// Applies the Liquid Glass surface on iOS 26 (with a shared `glassEffectID` so the
+/// card<->FAB transition morphs), and a `.ultraThinMaterial` + `matchedGeometryEffect`
+/// fallback on earlier OSes / SDKs.
+private struct GlassSurface: ViewModifier {
+    enum SurfaceShape {
+        case roundedRect(CGFloat)
+        case circle
+    }
+
+    let namespace: Namespace.ID
+    let glassID: String
+    let shape: SurfaceShape
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            switch shape {
+            case .roundedRect(let radius):
+                content
+                    .glassEffect(.regular.interactive(),
+                                 in: RoundedRectangle(cornerRadius: radius, style: .continuous))
+                    .glassEffectID(glassID, in: namespace)
+            case .circle:
+                content
+                    .glassEffect(.regular.interactive(), in: Circle())
+                    .glassEffectID(glassID, in: namespace)
+            }
+        } else {
+            fallback(content)
+        }
+        #else
+        fallback(content)
+        #endif
+    }
+
+    @ViewBuilder
+    private func fallback(_ content: Content) -> some View {
+        switch shape {
+        case .roundedRect(let radius):
+            let s = RoundedRectangle(cornerRadius: radius, style: .continuous)
+            content
+                .background(.ultraThinMaterial, in: s)
+                .overlay(s.strokeBorder(Color.primary.opacity(0.08), lineWidth: 1))
+                .matchedGeometryEffect(id: glassID, in: namespace)
+                .shadow(color: .black.opacity(0.18), radius: 10, x: 0, y: 4)
+        case .circle:
+            content
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().strokeBorder(Color.primary.opacity(0.08), lineWidth: 1))
+                .matchedGeometryEffect(id: glassID, in: namespace)
+                .shadow(color: .black.opacity(0.18), radius: 10, x: 0, y: 4)
+        }
+    }
+}
+
+// MARK: - Single card content
+
+private struct NearbyCardContentView: View {
+    let item: NearbyItem
+    let now: Date
+    let isFavorite: Bool
+    let audioPlayer: any AudioPlayerProtocol
+    let onFavoriteTap: () -> Void
+    let onTap: () -> Void
+
+    @StateObject private var assets: RowAssetsLoader
+    @Environment(\.themeColors) private var themeColors
+
+    init(
+        item: NearbyItem,
+        now: Date,
+        isFavorite: Bool,
+        audioPlayer: any AudioPlayerProtocol,
+        onFavoriteTap: @escaping () -> Void,
+        onTap: @escaping () -> Void
+    ) {
+        self.item = item
+        self.now = now
+        self.isFavorite = isFavorite
+        self.audioPlayer = audioPlayer
+        self.onFavoriteTap = onFavoriteTap
+        self.onTap = onTap
+        _assets = StateObject(wrappedValue: RowAssetsLoader(objectID: item.thumbnailObjectID))
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            thumbnail
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(themeColors.primaryColor)
+                    .lineLimit(1)
+
+                if let description = item.detailDescription, !description.isEmpty {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(themeColors.secondaryColor)
+                        .lineLimit(1)
+                }
+
+                if let timeText = item.eventTimeText(now: now) {
+                    Text(timeText)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(themeColors.detailColor)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 4)
+
+            VStack(spacing: 10) {
+                favoriteIcon
+                if let track = audioTrack {
+                    AudioTourButton(track: track, audioPlayer: audioPlayer)
+                }
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onTap() }
+    }
+
+    private var thumbnail: some View {
+        let shape = RoundedRectangle(cornerRadius: 10, style: .continuous)
+        return ZStack {
+            shape.fill(Color.black.opacity(0.06))
+            if let image = assets.thumbnail {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: item.placeholderSymbol)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: 60, height: 60)
+        .clipShape(shape)
+        .overlay(shape.strokeBorder(Color.primary.opacity(0.08), lineWidth: 1))
+    }
+
+    /// Uses `Image + onTapGesture` (not `Button`) so it doesn't swallow the card tap.
+    private var favoriteIcon: some View {
+        Image(systemName: isFavorite ? "heart.fill" : "heart")
+            .foregroundStyle(isFavorite ? Color.pink : themeColors.detailColor)
+            .imageScale(.medium)
+            .frame(width: 28, height: 28)
+            .contentShape(Rectangle())
+            .onTapGesture { onFavoriteTap() }
+    }
+
+    /// Audio tours exist for art only, and only when the file is present on disk.
+    private var audioTrack: BRCAudioTourTrack? {
+        guard let art = item.artForAudio, let audioURL = assets.audioURL else { return nil }
+        return BRCAudioTourTrack(
+            uid: art.uid,
+            title: art.name,
+            artist: art.artist,
+            audioURL: audioURL,
+            artworkURL: BRCMediaDownloader.localMediaURL("\(art.uid).jpg")
+        )
+    }
+}
+
+// MARK: - NearbyItem display helpers
+
+private extension NearbyItem {
+    /// Object id used for thumbnail/audio lookup (events fall back to host camp/art).
+    var thumbnailObjectID: String {
+        switch self {
+        case .art(let r): r.object.thumbnailObjectID
+        case .camp(let r): r.object.thumbnailObjectID
+        case .event(let r): r.object.thumbnailObjectID
+        }
+    }
+
+    var detailDescription: String? {
+        switch self {
+        case .art(let r): r.object.description
+        case .camp(let r): r.object.description
+        case .event(let r): r.object.description
+        }
+    }
+
+    /// Live event timing line (events only).
+    func eventTimeText(now: Date) -> String? {
+        if case .event(let r) = self { return r.object.timeDescription(now: now) }
+        return nil
+    }
+
+    /// Underlying art object, for building an audio-tour track (art only).
+    var artForAudio: ArtObject? {
+        if case .art(let r) = self { return r.object }
+        return nil
+    }
+
+    var placeholderSymbol: String {
+        switch self {
+        case .art: "photo"
+        case .camp: "tent"
+        case .event: "calendar"
+        }
+    }
+}

--- a/iBurn/Map/NearbyCard/NearbyCardViewModel.swift
+++ b/iBurn/Map/NearbyCard/NearbyCardViewModel.swift
@@ -1,0 +1,321 @@
+//
+//  NearbyCardViewModel.swift
+//  iBurn
+//
+//  Created by Claude Code on 5/30/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+//  Backing model for the on-map "nearby card" overlay. Emits a single flat,
+//  ordered, de-duped list of objects within a tight radius of the user, with
+//  events (happening now / starting soon) prioritized first, then art + camps
+//  by distance. This is NOT the full-screen Nearby list (NearbyViewModel) — it
+//  reuses the same data providers and `NearbyItem`, but produces a compact feed
+//  for the map card.
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+import PlayaDB
+
+@MainActor
+final class NearbyCardViewModel: ObservableObject {
+    // MARK: - Published
+
+    /// Ordered, de-duped nearby items: events first, then art + camps by distance.
+    @Published private(set) var items: [NearbyItem] = []
+
+    /// Currently paged item, tracked by `NearbyItem.id` (not index) so that location
+    /// updates re-ordering the feed don't yank the user mid-swipe.
+    @Published var selectedID: String?
+
+    /// Whether the card is collapsed into its FAB.
+    @Published var isMinimized: Bool = false
+
+    /// Live "now" for event timing display; refreshed on a timer.
+    @Published var now: Date = .present
+
+    // MARK: - Tuning
+
+    /// Only surface objects within this radius of the user (meters).
+    let nearbyRadius: CLLocationDistance = 100
+
+    /// Re-center the DB region query after the user moves at least this far (meters).
+    private let regionRecenterThreshold: CLLocationDistance = 25
+
+    /// Cap the pager so it stays light.
+    private let maxItems = 12
+
+    // MARK: - Dependencies
+
+    private let playaDB: PlayaDB
+    private let artProvider: ArtDataProvider
+    private let campProvider: CampDataProvider
+    private let eventProvider: EventDataProvider
+    private let locationProvider: LocationProvider
+
+    // MARK: - State
+
+    private var rawLocation: CLLocation?
+    private var lastRegionLocation: CLLocation?
+    private var artItems: [ListRow<ArtObject>] = []
+    private var campItems: [ListRow<CampObject>] = []
+    private var eventItems: [ListRow<EventObjectOccurrence>] = []
+
+    // MARK: - Tasks
+
+    private var artTask: Task<Void, Never>?
+    private var campTask: Task<Void, Never>?
+    private var eventTask: Task<Void, Never>?
+    private var locationTask: Task<Void, Never>?
+    private var timerTask: Task<Void, Never>?
+
+    // MARK: - Computed
+
+    var currentLocation: CLLocation? { rawLocation }
+
+    var count: Int { items.count }
+
+    /// A small region centered on the user for the DB region queries. Sized a bit
+    /// larger than `nearbyRadius` (a square bbox circumscribing the circle) so the
+    /// exact per-item distance filter in `rebuildItems()` is the precise gate.
+    var searchRegion: MKCoordinateRegion? {
+        guard let location = currentLocation else { return nil }
+        return MKCoordinateRegion(
+            center: location.coordinate,
+            latitudinalMeters: nearbyRadius * 2,
+            longitudinalMeters: nearbyRadius * 2
+        )
+    }
+
+    // MARK: - Init
+
+    init(
+        playaDB: PlayaDB,
+        artProvider: ArtDataProvider,
+        campProvider: CampDataProvider,
+        eventProvider: EventDataProvider,
+        locationProvider: LocationProvider
+    ) {
+        self.playaDB = playaDB
+        self.artProvider = artProvider
+        self.campProvider = campProvider
+        self.eventProvider = eventProvider
+        self.locationProvider = locationProvider
+
+        self.rawLocation = locationProvider.currentLocation
+        self.lastRegionLocation = rawLocation
+
+        startLocationUpdates()
+        startRefreshTimer()
+        restartObservations()
+    }
+
+    deinit {
+        artTask?.cancel()
+        campTask?.cancel()
+        eventTask?.cancel()
+        locationTask?.cancel()
+        timerTask?.cancel()
+    }
+
+    // MARK: - Favorites
+
+    func toggleFavorite(_ item: NearbyItem) async {
+        do {
+            switch item {
+            case .art(let row): try await artProvider.toggleFavorite(row.object)
+            case .camp(let row): try await campProvider.toggleFavorite(row.object)
+            case .event(let row): try await eventProvider.toggleFavorite(row.object)
+            }
+        } catch {
+            // Favorite state is driven by DB observation; a failed toggle is a no-op.
+        }
+    }
+
+    // MARK: - Item assembly
+
+    /// Recompute `items` from the latest observations + location. Events that are
+    /// happening now or starting soon come first (by start time); then art + camps
+    /// merged by distance. Everything is gated to `nearbyRadius`, de-duped by id,
+    /// and capped to `maxItems`.
+    private func rebuildItems() {
+        guard let location = currentLocation else {
+            items = []
+            reconcileSelection()
+            return
+        }
+        items = Self.orderedItems(
+            art: artItems,
+            camps: campItems,
+            events: eventItems,
+            from: location,
+            now: now,
+            radius: nearbyRadius,
+            maxItems: maxItems
+        )
+        reconcileSelection()
+    }
+
+    /// Pure ordering used by `rebuildItems()`, exposed for unit testing.
+    ///
+    /// Events that are happening now or starting soon come first (by start time);
+    /// then art + camps merged by distance. All gated to `radius`, de-duped by id,
+    /// capped to `maxItems`. Objects without a location are dropped.
+    static func orderedItems(
+        art: [ListRow<ArtObject>],
+        camps: [ListRow<CampObject>],
+        events: [ListRow<EventObjectOccurrence>],
+        from location: CLLocation,
+        now: Date,
+        radius: CLLocationDistance,
+        maxItems: Int
+    ) -> [NearbyItem] {
+        let orderedEvents = events
+            .filter { row in
+                guard let loc = row.object.location,
+                      location.distance(from: loc) <= radius else { return false }
+                return row.object.isCurrentlyHappening(now) || row.object.isStartingSoon(now)
+            }
+            .sorted { $0.object.startDate < $1.object.startDate }
+            .map { NearbyItem.event($0) }
+
+        var others: [(item: NearbyItem, distance: CLLocationDistance)] = []
+        for row in art {
+            guard let loc = row.object.location else { continue }
+            let distance = location.distance(from: loc)
+            if distance <= radius { others.append((.art(row), distance)) }
+        }
+        for row in camps {
+            guard let loc = row.object.location else { continue }
+            let distance = location.distance(from: loc)
+            if distance <= radius { others.append((.camp(row), distance)) }
+        }
+        let sortedOthers = others.sorted { $0.distance < $1.distance }.map(\.item)
+
+        var seen = Set<String>()
+        var combined: [NearbyItem] = []
+        for item in orderedEvents + sortedOthers {
+            guard seen.insert(item.id).inserted else { continue }
+            combined.append(item)
+            if combined.count >= maxItems { break }
+        }
+        return combined
+    }
+
+    /// Keep the paged selection stable across rebuilds; only reset when the
+    /// selected item is no longer present.
+    private func reconcileSelection() {
+        if let selectedID, items.contains(where: { $0.id == selectedID }) {
+            return
+        }
+        selectedID = items.first?.id
+    }
+
+    // MARK: - Observations
+
+    private func restartObservations() {
+        startArtObservation()
+        startCampObservation()
+        startEventObservation()
+    }
+
+    private func startArtObservation() {
+        artTask?.cancel()
+        guard let region = searchRegion else {
+            artItems = []
+            rebuildItems()
+            return
+        }
+        let filter = ArtFilter(region: region)
+        artTask = Task { [weak self] in
+            guard let self else { return }
+            for await rows in self.artProvider.observeObjects(filter: filter) {
+                await MainActor.run {
+                    self.artItems = rows
+                    self.rebuildItems()
+                }
+            }
+        }
+    }
+
+    private func startCampObservation() {
+        campTask?.cancel()
+        guard let region = searchRegion else {
+            campItems = []
+            rebuildItems()
+            return
+        }
+        let filter = CampFilter(region: region)
+        campTask = Task { [weak self] in
+            guard let self else { return }
+            for await rows in self.campProvider.observeObjects(filter: filter) {
+                await MainActor.run {
+                    self.campItems = rows
+                    self.rebuildItems()
+                }
+            }
+        }
+    }
+
+    private func startEventObservation() {
+        eventTask?.cancel()
+        guard let region = searchRegion else {
+            eventItems = []
+            rebuildItems()
+            return
+        }
+        // Region-filtered (R*Tree-backed). Fetch all in-region occurrences and apply the
+        // exact happening-now / starting-soon gate client-side at `now` (the region is
+        // tiny, and this also captures starting-soon events that `happeningNow` would drop).
+        let filter = EventFilter(includeExpired: true, region: region)
+        eventTask = Task { [weak self] in
+            guard let self else { return }
+            for await rows in self.eventProvider.observeObjects(filter: filter) {
+                await MainActor.run {
+                    self.eventItems = rows
+                    self.rebuildItems()
+                }
+            }
+        }
+    }
+
+    // MARK: - Location
+
+    private func startLocationUpdates() {
+        locationTask?.cancel()
+        locationTask = Task { [weak self] in
+            guard let self else { return }
+            for await location in self.locationProvider.locationStream {
+                guard let location else { continue }
+                await MainActor.run {
+                    self.rawLocation = location
+                    if let last = self.lastRegionLocation,
+                       location.distance(from: last) < self.regionRecenterThreshold {
+                        // Small move: re-sort / re-gate against the existing observations.
+                        self.rebuildItems()
+                    } else {
+                        // First fix or meaningful move: recenter the region queries.
+                        self.lastRegionLocation = location
+                        self.restartObservations()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Refresh timer
+
+    private func startRefreshTimer() {
+        timerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 30_000_000_000) // 30s
+                guard let self else { return }
+                await MainActor.run {
+                    self.now = .present
+                    self.rebuildItems()
+                }
+            }
+        }
+    }
+}

--- a/iBurnTests/NearbyCardViewModelTests.swift
+++ b/iBurnTests/NearbyCardViewModelTests.swift
@@ -1,0 +1,156 @@
+//
+//  NearbyCardViewModelTests.swift
+//  iBurnTests
+//
+//  Created by Claude Code on 5/30/26.
+//  Copyright © 2026 Burning Man Earth. All rights reserved.
+//
+//  Unit tests for the on-map nearby card ordering: events first (happening now /
+//  starting soon, by start time), then art + camps by distance, gated to the
+//  radius, de-duped by id, capped to maxItems.
+//
+
+import XCTest
+import CoreLocation
+import PlayaDB
+@testable import iBurn
+
+@MainActor
+final class NearbyCardViewModelTests: XCTestCase {
+
+    // User reference point and a shared longitude so distance varies only by latitude.
+    private let baseLat = 40.0
+    private let baseLon = -119.0
+    private lazy var userLocation = CLLocation(latitude: baseLat, longitude: baseLon)
+
+    // ~111,320 m per degree of latitude near the equator/BRC, so these are roughly:
+    private let lat33m = 40.0003   // ~33 m north
+    private let lat67m = 40.0006   // ~67 m north
+    private let lat89m = 40.0008   // ~89 m north
+    private let lat133m = 40.0012  // ~133 m north (outside a 100 m radius)
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Builders
+
+    private func artRow(_ uid: String, lat: Double) -> ListRow<ArtObject> {
+        ListRow(
+            object: ArtObject(uid: uid, name: uid, year: 2025, gpsLatitude: lat, gpsLongitude: baseLon),
+            metadata: nil,
+            thumbnailColors: nil
+        )
+    }
+
+    private func campRow(_ uid: String, lat: Double) -> ListRow<CampObject> {
+        ListRow(
+            object: CampObject(uid: uid, name: uid, year: 2025, gpsLatitude: lat, gpsLongitude: baseLon),
+            metadata: nil,
+            thumbnailColors: nil
+        )
+    }
+
+    private func eventRow(_ uid: String, lat: Double, start: Date, end: Date) -> ListRow<EventObjectOccurrence> {
+        let event = EventObject(
+            uid: uid,
+            name: uid,
+            year: 2025,
+            eventTypeLabel: "Party",
+            eventTypeCode: "prty",
+            gpsLatitude: lat,
+            gpsLongitude: baseLon
+        )
+        let occurrence = EventOccurrence(eventUid: uid, startTime: start, endTime: end, year: 2025)
+        let combined = EventObjectOccurrence(event: event, occurrence: occurrence, host: nil)
+        return ListRow(object: combined, metadata: nil, thumbnailColors: nil)
+    }
+
+    private func order(
+        art: [ListRow<ArtObject>] = [],
+        camps: [ListRow<CampObject>] = [],
+        events: [ListRow<EventObjectOccurrence>] = [],
+        radius: CLLocationDistance = 100,
+        maxItems: Int = 12
+    ) -> [NearbyItem] {
+        NearbyCardViewModel.orderedItems(
+            art: art,
+            camps: camps,
+            events: events,
+            from: userLocation,
+            now: now,
+            radius: radius,
+            maxItems: maxItems
+        )
+    }
+
+    // MARK: - Tests
+
+    func testEventsComeFirstThenArtAndCampsByDistance() throws {
+        // Event is the farthest of the in-radius items but must still come first.
+        let happeningEvent = eventRow("E", lat: lat89m,
+                                      start: now.addingTimeInterval(-600),
+                                      end: now.addingTimeInterval(3000))
+        let items = order(
+            art: [artRow("A", lat: lat33m)],
+            camps: [campRow("C", lat: lat67m)],
+            events: [happeningEvent]
+        )
+
+        XCTAssertEqual(items.count, 3)
+        XCTAssertTrue(items[0].id.hasPrefix("event-"), "Events must be prioritized first")
+        XCTAssertEqual(items[1].id, "art-A", "Then nearest non-event (33 m)")
+        XCTAssertEqual(items[2].id, "camp-C", "Then next nearest (67 m)")
+    }
+
+    func testItemsBeyondRadiusAreExcluded() throws {
+        let items = order(
+            art: [artRow("near", lat: lat33m), artRow("far", lat: lat133m)]
+        )
+
+        XCTAssertEqual(items.map(\.id), ["art-near"])
+        XCTAssertFalse(items.contains { $0.id == "art-far" })
+    }
+
+    func testArtAndCampsSortedByDistance() throws {
+        let items = order(
+            art: [artRow("artFar", lat: lat67m)],
+            camps: [campRow("campNear", lat: lat33m)]
+        )
+
+        XCTAssertEqual(items.map(\.id), ["camp-campNear", "art-artFar"])
+    }
+
+    func testEndedEventIsExcluded() throws {
+        let endedEvent = eventRow("ended", lat: lat33m,
+                                  start: now.addingTimeInterval(-7200),
+                                  end: now.addingTimeInterval(-3600))
+        let items = order(events: [endedEvent])
+
+        XCTAssertTrue(items.isEmpty, "Events that have ended should not appear")
+    }
+
+    func testDuplicateIdsAreDeduped() throws {
+        let items = order(art: [artRow("dup", lat: lat33m), artRow("dup", lat: lat67m)])
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.id, "art-dup")
+    }
+
+    func testResultIsCappedToMaxItems() throws {
+        let art = (0..<10).map { artRow("art\($0)", lat: lat33m) }
+        let items = order(art: art, maxItems: 4)
+
+        XCTAssertEqual(items.count, 4)
+    }
+
+    func testNoLocationObjectsAreDropped() throws {
+        // An art object with no GPS (location == nil) must be dropped.
+        let noGPS = ListRow(
+            object: ArtObject(uid: "noGPS", name: "noGPS", year: 2025),
+            metadata: nil,
+            thumbnailColors: nil
+        )
+        let items = order(art: [noGPS, artRow("withGPS", lat: lat33m)])
+
+        XCTAssertEqual(items.map(\.id), ["art-withGPS"])
+    }
+}


### PR DESCRIPTION
## What

A compact, swipeable SwiftUI card pinned near the bottom of the main map that surfaces the art/camps/events within ~100m of the user. Events come first (happening now / starting soon, ordered by start time), then art + camps by distance.

- **Swipe** between nearby items; **tap** opens the detail view.
- **Favorite heart** + **audio-tour play button** (art with audio only).
- **Minimize** collapses the card into a badged FAB; iOS 26 **Liquid Glass** morph between card ↔ FAB, with a `.ultraThinMaterial` + matched-geometry fallback for the iOS 16.6 deployment target.
- Hosted as a **proper child view controller** of the UIKit map (`addChild`/`didMove`, intrinsic-content sizing so the rest of the map stays interactive) — the inner `UIView` is not extracted.

## Why this targets `ai-event-summary`

Branched from `ai-event-summary` and rebased onto its latest commit (`a455b2e`, the spatio-temporal R*Tree for event region queries) so the card's `EventFilter(region:)` queries are indexed and correct (events hosted by in-region camps now return). Reuses the existing data layer (`NearbyItem`, data providers, `RowAssetsLoader`, `AudioTourButton`, `DetailViewControllerFactory`, `CoreLocationProvider`) — only the UI is new. This is separate from the planned Nearby + Right Now merge.

## Files

- New: `iBurn/Map/NearbyCard/{NearbyCardViewModel,NearbyCardView,NearbyCardHostingController}.swift`
- New: `iBurnTests/NearbyCardViewModelTests.swift`, `Docs/2026-05-30-nearby-card-on-map.md`
- Modified: `iBurn/DependencyContainer.swift` (`makeNearbyCardViewModel()`), `iBurn/MainMapViewController.swift` (`setupNearbyCard()`)

## Test plan

- `NearbyCardViewModelTests` covers the pure ordering: events-first (even when farther), distance sort, radius exclusion, ended-event exclusion, dedup by id, cap to maxItems, no-GPS drop.
- ⚠️ A green `xcodebuild` build + test run was **not reconfirmed in this session** — the runs failed at SPM package dependency resolution (environment/network), not a code error. Please run locally:
  `xcodebuild test -workspace iBurn.xcworkspace -scheme iBurnTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.2,arch=arm64' -only-testing:iBurnTests/NearbyCardViewModelTests`
- On-device/simulator visual confirmation pending (location data is embargoed until gates open, so nearby objects won't have coordinates yet).

Draft — left as draft pending the build/test + visual verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
